### PR TITLE
Fix reference issue

### DIFF
--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -90,7 +90,10 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
+
+                # Ignore unused variable rules for attachments like this using "noqa" statements for rule F841.
+                # Ref: https://docs.astral.sh/ruff/rules/unused-variable/
+                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
                     f'{name}-polatt-ecrpush',
                     users=[user],
                     policy_arn=ecr_image_push_policy.arn,
@@ -117,7 +120,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_upload_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
+                s3_upload_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
                     f'{name}-polatt-s3upload',
                     users=[user],
                     policy_arn=s3_upload_policy.arn,
@@ -148,7 +151,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_full_access_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
+                s3_full_access_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
                     f'{name}-polatt-s3fullaccess',
                     users=[user],
                     policy_arn=s3_full_access_policy.arn,

--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -90,7 +90,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment(
+                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-ecrpush',
                     users=[user],
                     policy_arn=ecr_image_push_policy.arn,
@@ -117,7 +117,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_upload_policy_attachment = aws.iam.PolicyAttachment(
+                s3_upload_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-s3upload',
                     users=[user],
                     policy_arn=s3_upload_policy.arn,
@@ -148,7 +148,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_full_access_policy_attachment = aws.iam.PolicyAttachment(
+                s3_full_access_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-s3fullaccess',
                     users=[user],
                     policy_arn=s3_full_access_policy.arn,
@@ -209,7 +209,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                fargate_deployment_policy_attachment = aws.iam.PolicyAttachment(
+                fargate_deployment_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-fargatedeploy',
                     users=[user],
                     policy_arn=fargate_deployment_policy.arn,
@@ -243,11 +243,5 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     's3_upload_policy': None,
                     's3_full_access_policy': None,
                     'fargate_deployment_policy': None,
-                    'iam_policy_attachments': [
-                        ecr_image_push_policy_attachment,
-                        s3_upload_policy_attachment,
-                        s3_full_access_policy_attachment,
-                        fargate_deployment_policy_attachment,
-                    ],
                 },
             )

--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -93,7 +93,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
 
                 # Ignore unused variable rules for attachments like this using "noqa" statements for rule F841.
                 # Ref: https://docs.astral.sh/ruff/rules/unused-variable/
-                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
+                ecr_image_push_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-ecrpush',
                     users=[user],
                     policy_arn=ecr_image_push_policy.arn,
@@ -120,7 +120,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_upload_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
+                s3_upload_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-s3upload',
                     users=[user],
                     policy_arn=s3_upload_policy.arn,
@@ -151,7 +151,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                     policy=policy_json,
                     opts=pulumi.ResourceOptions(parent=self),
                 )
-                s3_full_access_policy_attachment = aws.iam.PolicyAttachment( # noqa: F841
+                s3_full_access_policy_attachment = aws.iam.PolicyAttachment(  # noqa: F841
                     f'{name}-polatt-s3fullaccess',
                     users=[user],
                     policy_arn=s3_full_access_policy.arn,


### PR DESCRIPTION
This fixes an issue where running the `AwsAutomationUser` against a stack that doesn't build CI resources results in a variable reference error like this:

```
Diagnostics:
  pulumi:pulumi:Stack (send-suite-ci):
    The current stack is "ci", but CI components are associated with the"staging" stack. These resources will be skipped on this run.
    error: Program failed with an unhandled exception:
    Traceback (most recent call last):
      File "/home/rjung/workspace/thunderbird/send-suite/pulumi/__main__.py", line 135, in <module>
        ci_iam = tb_pulumi.ci.AwsAutomationUser(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/rjung/workspace/thunderbird/send-suite/pulumi/venv/lib64/python3.12/site-packages/tb_pulumi/ci.py", line 247, in __init__
        ecr_image_push_policy_attachment,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    UnboundLocalError: cannot access local variable 'ecr_image_push_policy_attachment' where it is not associated with a value
```

This bug got introduced because Ruff wants us to define variables only if we're going to reference them elsewhere, so I came up with a bad excuse to use these variable names. I guess I could have solved this by just not storing these `PolicyAttachments` in any variables at all, but that feels "out of pattern" to me. Instead, I've just exempted this single problem from linting.