### PR TITLE
Refactor secrets module, allow destruction of non-empty S3 buckets used for CF distros

### DIFF
--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -38,6 +38,11 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         <https://www.pulumi.com/registry/packages/aws/api-docs/cloudfront/distribution>`_. Defaults to {}.
     :type distribution: dict, optional
 
+    :param forcibly_destroy_buckets: When True, the service bucket and logging bucket will both be forcibly emptied -
+        all their contents **destroyed beyond recovery** - when the bucket resource is destroyed. This is dangerous, as
+        it bypasses protections against data loss. Only enable this for volatile environments. Defaults to False.
+    :type forcibly_destroy_buckets bool, optional
+
     :param origins: List of `DistributionOrigin
         <https://www.pulumi.com/registry/packages/aws/api-docs/cloudfront/distribution/#distributionorigin>`_ objects to
         add. This list should not include any references to the S3 bucket, which is managed by this module. Defaults to
@@ -56,6 +61,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         service_bucket_name: str,
         behaviors: list[dict] = [],
         distribution: dict = {},
+        forcibly_destroy_buckets: bool = False,
         origins: list[dict] = [],
         opts: pulumi.ResourceOptions = None,
         **kwargs,
@@ -67,6 +73,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         service_bucket = aws.s3.Bucket(
             f'{name}-servicebucket',
             bucket=service_bucket_name,
+            force_destroy=forcibly_destroy_buckets,
             server_side_encryption_configuration={
                 'rule': {'applyServerSideEncryptionByDefault': {'sseAlgorithm': 'AES256'}, 'bucket_key_enabled': True}
             },
@@ -78,6 +85,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         logging_bucket = aws.s3.Bucket(
             f'{name}-loggingbucket',
             bucket=f'{service_bucket_name}-logs',
+            force_destroy=forcibly_destroy_buckets,
             server_side_encryption_configuration={
                 'rule': {'applyServerSideEncryptionByDefault': {'sseAlgorithm': 'AES256'}, 'bucket_key_enabled': True}
             },

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -90,7 +90,7 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-        super().__init__('tb:secrets:PulumiSecretsManager', name, project, opts=opts, **kwargs)
+        super().__init__('tb:secrets:PulumiSecretsManager', name, project, opts=opts)
         secrets = []
 
         # First build the secrets

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -43,7 +43,6 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
     ):
         super().__init__('tb:secrets:SecretsManagerSecret', name, project, opts=opts)
 
-        short_name = secret_name.split('/')[-1]
         secret = aws.secretsmanager.Secret(
             f'{name}-secret', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
         )

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -106,7 +106,7 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
                 secret_name=secret_fullname,
                 secret_value=secret_string,
                 opts=pulumi.ResourceOptions(parent=self),
-                **kwargs
+                **kwargs,
             )
             secrets.append(secret)
 

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -49,7 +49,7 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         )
 
         version = aws.secretsmanager.SecretVersion(
-            f'{name}-secretversion-{short_name}',
+            f'{name}-secretversion',
             secret_id=secret.id,
             secret_string=secret_value,
             opts=pulumi.ResourceOptions(parent=self, depends_on=[secret]),
@@ -101,7 +101,7 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
             # Use our module to build a secret
             secret_fullname = f'{self.project.project}/{self.project.stack}/{secret_name}'
             secret = SecretsManagerSecret(
-                name=f'{name}-secret-{secret_name}',
+                name=f'{name}-{secret_name}',
                 project=self.project,
                 secret_name=secret_fullname,
                 secret_value=secret_string,

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -45,7 +45,7 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
 
         short_name = secret_name.split('/')[-1]
         secret = aws.secretsmanager.Secret(
-            f'{name}-secret-{short_name}', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
+            f'{name}-secret', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
         )
 
         version = aws.secretsmanager.SecretVersion(

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -28,8 +28,8 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
     :param opts: Additional pulumi.ResourceOptions to apply to these resources. Defaults to None.
     :type opts: pulumi.ResourceOptions, optional
 
-    :param kwargs: Any other keyword arguments which will be passed as inputs to the ThunderbirdComponentResource
-        superconstructor.
+    :param kwargs: Any other keyword arguments which will be passed as inputs to the ``aws.secretsmanager.Secret``
+        resource.
     """
 
     def __init__(
@@ -41,11 +41,11 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-        super().__init__('tb:secrets:SecretsManagerSecret', name, project, opts=opts, **kwargs)
+        super().__init__('tb:secrets:SecretsManagerSecret', name, project, opts=opts)
 
         short_name = secret_name.split('/')[-1]
         secret = aws.secretsmanager.Secret(
-            f'{name}-secret-{short_name}', opts=pulumi.ResourceOptions(parent=self), name=secret_name
+            f'{name}-secret-{short_name}', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
         )
 
         version = aws.secretsmanager.SecretVersion(
@@ -78,8 +78,8 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
         - kwargs: Any other keyword arguments which will be passed as inputs to the
             ThunderbirdComponentResource superconstructor.
 
-    :param kwargs: Any other keyword arguments which will be passed as inputs to the ThunderbirdComponentResource
-        superconstructor.
+    :param kwargs: Any other keyword arguments which will be passed as inputs to the ``aws.secretsmanager.Secret``
+        resource.
     """
 
     def __init__(
@@ -92,32 +92,26 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
     ):
         super().__init__('tb:secrets:PulumiSecretsManager', name, project, opts=opts, **kwargs)
         secrets = []
-        versions = []
 
         # First build the secrets
         for secret_name in secret_names:
             # Pull the secret's value from Pulumi's encrypted state
             secret_string = self.project.pulumi_config.require_secret(secret_name)
 
-            # Declare a Secrets Manager Secret
+            # Use our module to build a secret
             secret_fullname = f'{self.project.project}/{self.project.stack}/{secret_name}'
-            secret = aws.secretsmanager.Secret(
-                f'{name}-secret-{secret_name}', opts=pulumi.ResourceOptions(parent=self), name=secret_fullname
+            secret = SecretsManagerSecret(
+                name=f'{name}-secret-{secret_name}',
+                project=self.project,
+                secret_name=secret_fullname,
+                secret_value=secret_string,
+                opts=pulumi.ResourceOptions(parent=self),
+                **kwargs
             )
             secrets.append(secret)
 
-            # Populate its value
-            versions.append(
-                aws.secretsmanager.SecretVersion(
-                    f'{name}-secretversion-{secret_name}',
-                    opts=pulumi.ResourceOptions(parent=self),
-                    secret_id=secret.id,
-                    secret_string=secret_string,
-                )
-            )
-
         # Then create an IAM policy allowing access to them
-        secret_arns = [secret.arn for secret in secrets]
+        secret_arns = [secret.resources['secret'].arn for secret in secrets]
         policy = pulumi.Output.all(*secret_arns).apply(
             lambda secret_arns: json.dumps(
                 {
@@ -143,5 +137,5 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
 
         self.finish(
             outputs={'policy_id': policy.policy_id, 'secret_ids': [secret.id for secret in secrets]},
-            resources={'secrets': secrets, 'versions': versions, 'policy': policy},
+            resources={'secrets': secrets, 'policy': policy},
         )


### PR DESCRIPTION
## Description of the Change

Two changes here:

- The classes in the `secrets` module have been reworked to allow full control over the inputs to Secrets Manager secrets. `PulumiSecretsManager` has been reworked to make use of the `SecretsManagerSecret` module. This will lead to recreation of these resources in any stack upgrading to a version including this code.
- The CloudFrontS3Service class now accepts a `forcibly_destroy_buckets` option that allows a stack to delete an S3 bucket's contents when the bucket is destroyed. This is to be used in volatile dev or CI environments where the infrastructure itself is being tested.

## Benefits

- Better reuse of our own classes within the secrets module
- More configurability with secrets
- Volatile environments can now be destroyed and rebuilt without running into problems of non-empty S3 buckets and non-deleted secrets stuck in their retention period.

## Applicable Issues

Issue #32 
