### PR TITLE
Lock AWS provider version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<44.0
 pulumi>=3.130.0,<4.0.0
-pulumi-aws>=6.0.2,<7.0.0
+pulumi-aws==6.57.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi


### PR DESCRIPTION
Issue #43 has some details. This prevents a problem where Pulumi can't do a targeted run if it's been told to use a new provider. The full stack has to have a `pulumi up` run before targeted runs will work again.