### PR TITLE
Initial monitoring setup

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,4 @@ infrastructure as code tool.
    ./getting-started
    ./patterns
    ./modules
+   ./monitoring

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -1,0 +1,23 @@
+Monitoring Resources
+====================
+
+When you use a ``ThunderbirdPulumiProject`` and add ``ThunderbirdComponentResource``s to it, the project tracks the
+resources in an internal mapping correlating the name of the module to a collection of its resources. These resources
+can have complex structures with nested lists, dicts, and ``ThunderbirdComponentResource``s. The project's
+:py:meth:`tb_pulumi.ThunderbirdPulumiProject.flatten` function returns these as a flat list of unlabeled Pulumi
+``Resource``s.
+
+The ``monitoring`` module contains two base classes intended to provide common interfaces to building monitoring
+patterns. The first is a ``MonitoringGroup``. This is little more than a ``ThunderbirdComponentResource`` that contains
+a config dictionary. The purpose is to contain the resources involved in a monitoring solution. That is, alarms and a
+notification setup.
+
+You should extend this class such that the resources returned by ``flatten`` are iterated over. If your module
+understands that a resource it comes across can be monitored, the class should create alarms via an extension of the
+second class, ``AlarmGroup``. This base class should be extended such that it creates alarms for a specific single
+resource. For example, a single load balancer might have many different metrics being monitored.
+
+As an example, take a look at :py:class:`tb_pulumi.cloudwatch.CloudWatchMonitoringGroup`, a ``MonitoringGroup``
+extension that uses AWS CloudWatch to alarm on metrics produced by AWS resources. It creates an
+:py:class:`tb_pulumi.cloudwatch.AlbAlarmGroup` when it encounters an application load balancer. That alarm group
+monitors status codes and response times.

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -1,11 +1,11 @@
 Monitoring Resources
 ====================
 
-When you use a ``ThunderbirdPulumiProject`` and add ``ThunderbirdComponentResource``s to it, the project tracks the
+When you use a ``ThunderbirdPulumiProject`` and add ``ThunderbirdComponentResource`` s to it, the project tracks the
 resources in an internal mapping correlating the name of the module to a collection of its resources. These resources
 can have complex structures with nested lists, dicts, and ``ThunderbirdComponentResource``s. The project's
 :py:meth:`tb_pulumi.ThunderbirdPulumiProject.flatten` function returns these as a flat list of unlabeled Pulumi
-``Resource``s.
+``Resource`` s.
 
 The ``monitoring`` module contains two base classes intended to provide common interfaces to building monitoring
 patterns. The first is a ``MonitoringGroup``. This is little more than a ``ThunderbirdComponentResource`` that contains

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -86,8 +86,10 @@ class ThunderbirdPulumiProject:
         with open(config_file, 'r') as fh:
             return yaml.load(fh.read(), Loader=yaml.SafeLoader)
 
-    def flatten(self) -> tuple[pulumi.Resource]:
-        return set(flatten(self.resources))
+    def flatten(self) -> set[pulumi.Resource]:
+        """Returns a flat set of all resources existing within this project."""
+
+        return flatten(self.resources)
 
 
 class ThunderbirdComponentResource(pulumi.ComponentResource):
@@ -214,7 +216,18 @@ def env_var_is_true(name: str) -> bool:
     return env_var_matches(name, ['t', 'true', 'yes'], False)
 
 
-def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource, prefix: str = ''):
+def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource) -> set[pulumi.Resource]:
+    """Recursively traverses a nested collection of Pulumi ``Resource``s, converting them into a flat set which can be
+    more easily iterated over.
+
+    :param item: Either a Pulumi ``Resource`` object, or some collection thereof. The following types of collections are
+        supported: ``dict``, ``list``, ``ThunderbirdComponentResource``.
+    :type item: dict | list | ThunderbirdComponentResource
+
+    :return: A ``set`` of Pulumi ``Resource``s contained within the collection.
+    :rtype: set(pulumi.Resource)
+    """
+
     # The item could be of a variety of types. When the item is some kind of collection, we should compress it down into
     # a flat list first, then operate on its items.
     flattened = []
@@ -234,4 +247,4 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource, 
         for item in to_flatten:
             flattened.extend(flatten(item))
 
-    return flattened
+    return set(flattened)

--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -314,7 +314,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
             )
         else:
             msg = (
-                f'The current stack is "{project.stack}", but CI components are associated with the'
+                f'The current stack is "{project.stack}", but CI components are associated with the '
                 + f'"{active_stack}" stack. These resources will be skipped on this run.'
             )
             pulumi.info(msg)

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -3,15 +3,25 @@
 import pulumi
 import pulumi_aws as aws
 import tb_pulumi
+import tb_pulumi.monitoring
 
 
-class CloudWatchMonitoring(tb_pulumi.ThunderbirdComponentResource):
+class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
     def __init__(
-        self, name: str, project: tb_pulumi.ThunderbirdPulumiProject, opts: pulumi.ResourceOptions = None, **kwargs
+        self,
+        name: str,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        opts: pulumi.ResourceOptions = None,
+        config: dict = {},
     ):
-        super().__init__('tb:cloudwatch:CloudWatchMonitoring', name=name, project=project, opts=opts, **kwargs)
+        super().__init__(
+            pulumi_type='tb:cloudwatch:CloudWatchMonitoringGroup', name=name, project=project, opts=opts, config=config
+        )
 
-        supported_types = {aws.lb.load_balancer.LoadBalancer: ApplicationLoadBalancerAlerts}
+        supported_types = {
+            # aws.lb.load_balancer.LoadBalancer: AlbAlertGroup,
+            aws.ecs.Service: FargateServiceAlertGroup
+        }
         supported_resources = [
             resource for resource in self.project.flatten() if type(resource) in supported_types.keys()
         ]
@@ -26,30 +36,111 @@ class CloudWatchMonitoring(tb_pulumi.ThunderbirdComponentResource):
             alerts[res._name] = supported_types[type(res)](
                 name=f'{res._name}',
                 project=self.project,
+                resource=res,
+                monitoring_group=self,
                 opts=pulumi.ResourceOptions(parent=self),
             )
 
         self.finish(outputs={'sns_topic_arn': sns_topic.arn}, resources={'sns_topic': sns_topic, 'alerts': alerts})
 
 
-class ApplicationLoadBalancerAlerts(tb_pulumi.ThunderbirdComponentResource):
+class AlbAlertGroup(tb_pulumi.monitoring.AlertGroup):
     def __init__(
-        self, name: str, project: tb_pulumi.ThunderbirdPulumiProject, opts: pulumi.ResourceOptions = None, **kwargs
+        self,
+        name: str,
+        monitoring_group: tb_pulumi.monitoring.MonitoringGroup,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        resource: pulumi.Resource,
+        opts: pulumi.ResourceOptions = None,
+        **kwargs,
     ):
-        super().__init__('tb:cloudwatch:CloudWatchMonitoring', name=name, project=project, opts=opts, **kwargs)
+        super().__init__(
+            'tb:cloudwatch:AlbAlertGroup', name=name, project=project, resource=resource, opts=opts, **kwargs
+        )
 
-        five_x_x = aws.cloudwatch.MetricAlarm(
+        fivexx_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 10}
+        fivexx_opts.update(self.overrides['fivexx'] if 'fivexx' in self.overrides else {})
+        fivexx = aws.cloudwatch.MetricAlarm(
             f'{self.name}-5xx',
             name=f'{self.project.name_prefix}-5xx',
             comparison_operator='GreaterThanOrEqualToThreshold',
-            evaluation_periods=2,
             metric_name='HTTPCode_ELB_5XX_Count',
             namespace='AWS/ApplicationELB',
-            period=300,
-            statistic='Average',
-            threshold=1,
-            alarm_description='5xx errors on this ALB',
-            opts=pulumi.ResourceOptions(parent=self)
+            alarm_description=f'Elevated 5xx errors on ALB {resource.name}',
+            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+            **fivexx_opts,
         )
 
-        self.finish(outputs={}, resources={'five_x_x': five_x_x})
+        response_time_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 1}
+        response_time_opts.update(self.overrides['response_time'] if 'response_time' in self.overrides else {})
+        response_time = aws.cloudwatch.MetricAlarm(
+            f'{self.name}-responsetime',
+            name=f'{self.project.name_prefix}-responsetime',
+            comparison_operator='GreaterThanOrEqualToThreshold',
+            metric_name='TargetResponseTime',
+            namespace='AWS/ApplicationELB',
+            alarm_description=f'Average response time is over {response_time_opts['threshold']} second(s) for {response_time_opts['period']} seconds',  # noqa: E501
+            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+        )
+
+        self.finish(outputs={}, resources={'five_x_x': fivexx, 'response_time': response_time})
+
+
+class FargateServiceAlertGroup(tb_pulumi.monitoring.AlertGroup):
+    def __init__(
+        self,
+        name: str,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        resource: pulumi.Resource,
+        monitoring_group: tb_pulumi.monitoring.MonitoringGroup,
+        opts: pulumi.ResourceOptions = None,
+        **kwargs,
+    ):
+        super().__init__(
+            'tb:cloudwatch:FargateClusterAlertGroup',
+            name=name,
+            project=project,
+            resource=resource,
+            monitoring_group=monitoring_group,
+            opts=opts,
+            **kwargs,
+        )
+
+        cpu_utilization_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 80}
+        cpu_utilization_opts.update(self.overrides['cpu_utilization'] if 'cpu_utilization' in self.overrides else {})
+        cpu_utilization_desc = resource.name.apply(
+            lambda resource_name: f'CPU utilization on the {resource_name} service exceeds {cpu_utilization_opts['threshold']}%'  # noqa: E501
+        )
+        cpu_utilization_alarm = aws.cloudwatch.MetricAlarm(
+            f'{self.name}-cpu',
+            name=f'{self.project.name_prefix}-cpu',
+            comparison_operator='GreaterThanOrEqualToThreshold',
+            metric_name='CPUUtilization',
+            namespace='AWS/ECS',
+            alarm_description=cpu_utilization_desc,
+            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+            **cpu_utilization_opts,
+        )
+
+        memory_utilization_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 80}
+        memory_utilization_opts.update(
+            self.overrides['memory_utilization'] if 'memory_utilization' in self.overrides else {}
+        )
+        memory_utilization_desc = resource.name.apply(
+            lambda resource_name: f'Memory utilization on the {resource_name} cluster exceeds {memory_utilization_opts['threshold']}%'  # noqa: E501
+        )
+        memory_utilization = aws.cloudwatch.MetricAlarm(
+            f'{self.name}-memory',
+            name=f'{self.project.name_prefix}-memory',
+            comparison_operator='GreaterThanOrEqualToThreshold',
+            metric_name='MemoryUtilization',
+            namespace='AWS/ECS',
+            alarm_description=memory_utilization_desc,
+            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+            **memory_utilization_opts,
+        )
+
+        self.finish(
+            outputs={},
+            resources={'cpu_utilization': cpu_utilization_alarm, 'memory_utilization': memory_utilization},
+        )

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -1,0 +1,55 @@
+"""Infrastructural patterns related to AWS CloudWatch."""
+
+import pulumi
+import pulumi_aws as aws
+import tb_pulumi
+
+
+class CloudWatchMonitoring(tb_pulumi.ThunderbirdComponentResource):
+    def __init__(
+        self, name: str, project: tb_pulumi.ThunderbirdPulumiProject, opts: pulumi.ResourceOptions = None, **kwargs
+    ):
+        super().__init__('tb:cloudwatch:CloudWatchMonitoring', name=name, project=project, opts=opts, **kwargs)
+
+        supported_types = {aws.lb.load_balancer.LoadBalancer: ApplicationLoadBalancerAlerts}
+        supported_resources = [
+            resource for resource in self.project.flatten() if type(resource) in supported_types.keys()
+        ]
+
+        sns_topic = aws.sns.Topic(
+            f'{name}-topic', name=f'{self.project.name_prefix}-alerting', opts=pulumi.ResourceOptions(parent=self)
+        )
+
+        alerts = {}
+        for res in supported_resources:
+            pulumi.info(f'Supported resource: {res}')
+            alerts[res._name] = supported_types[type(res)](
+                name=f'{res._name}',
+                project=self.project,
+                opts=pulumi.ResourceOptions(parent=self),
+            )
+
+        self.finish(outputs={'sns_topic_arn': sns_topic.arn}, resources={'sns_topic': sns_topic, 'alerts': alerts})
+
+
+class ApplicationLoadBalancerAlerts(tb_pulumi.ThunderbirdComponentResource):
+    def __init__(
+        self, name: str, project: tb_pulumi.ThunderbirdPulumiProject, opts: pulumi.ResourceOptions = None, **kwargs
+    ):
+        super().__init__('tb:cloudwatch:CloudWatchMonitoring', name=name, project=project, opts=opts, **kwargs)
+
+        five_x_x = aws.cloudwatch.MetricAlarm(
+            f'{self.name}-5xx',
+            name=f'{self.project.name_prefix}-5xx',
+            comparison_operator='GreaterThanOrEqualToThreshold',
+            evaluation_periods=2,
+            metric_name='HTTPCode_ELB_5XX_Count',
+            namespace='AWS/ApplicationELB',
+            period=300,
+            statistic='Average',
+            threshold=1,
+            alarm_description='5xx errors on this ALB',
+            opts=pulumi.ResourceOptions(parent=self)
+        )
+
+        self.finish(outputs={}, resources={'five_x_x': five_x_x})

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -7,140 +7,259 @@ import tb_pulumi.monitoring
 
 
 class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
+    """A ``MonitoringGroup`` that monitors AWS-based resources using AWS's CloudWatch service. This creates an SNS topic
+    to sent its alarms on.
+
+    :param name: The name of the ``CloudWatchMonitoringGroup`` resource.
+    :type name: str
+
+    :param project: The ``ThunderbirdPulumiProject`` to build monitoring resources for.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param config: A configuration dictionary for this monitoring group. Documentation for
+        :py:class:`tb_pulumi.monitoring.MonitoringGroup` defines the overall structure of this dict. The monitors are
+        defined as CloudWatch Metric Alarms and can be configured with the inputs `documented here
+        <https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/metricalarm/>`_. Defaults to {}.
+    :type config: dict, optional
+
+    :param opts: Additional ``pulumi.ResourceOptions`` to apply to this resource. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+    """
+
     def __init__(
         self,
         name: str,
         project: tb_pulumi.ThunderbirdPulumiProject,
-        opts: pulumi.ResourceOptions = None,
         config: dict = {},
+        opts: pulumi.ResourceOptions = None,
     ):
         super().__init__(
             pulumi_type='tb:cloudwatch:CloudWatchMonitoringGroup', name=name, project=project, opts=opts, config=config
         )
 
-        supported_types = {
-            # aws.lb.load_balancer.LoadBalancer: AlbAlertGroup,
-            aws.ecs.Service: FargateServiceAlertGroup
-        }
+        supported_types = {aws.lb.load_balancer.LoadBalancer: AlbAlarmGroup, aws.ecs.Service: EcsServiceAlarmGroup}
         supported_resources = [
             resource for resource in self.project.flatten() if type(resource) in supported_types.keys()
         ]
 
         sns_topic = aws.sns.Topic(
-            f'{name}-topic', name=f'{self.project.name_prefix}-alerting', opts=pulumi.ResourceOptions(parent=self)
+            f'{name}-topic', name=f'{self.project.name_prefix}-alarms', opts=pulumi.ResourceOptions(parent=self)
         )
 
-        alerts = {}
+        alarms = {}
         for res in supported_resources:
             pulumi.info(f'Supported resource: {res}')
-            alerts[res._name] = supported_types[type(res)](
-                name=f'{res._name}',
+            shortname = res._name.replace(f'{self.project.name_prefix}-', '') # Make this name shorter, less redundant
+            alarms[res._name] = supported_types[type(res)](
+                name=f'{name}-{shortname}',
                 project=self.project,
                 resource=res,
                 monitoring_group=self,
                 opts=pulumi.ResourceOptions(parent=self),
             )
 
-        self.finish(outputs={'sns_topic_arn': sns_topic.arn}, resources={'sns_topic': sns_topic, 'alerts': alerts})
+        self.finish(outputs={'sns_topic_arn': sns_topic.arn}, resources={'sns_topic': sns_topic, 'alarms': alarms})
 
 
-class AlbAlertGroup(tb_pulumi.monitoring.AlertGroup):
+class AlbAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
+    """A set of alarms for Application Load Balancers. Contains the following configurable alarms:
+
+        - ``fivexx``: Alarms on the number of HTTP responses with status codes in the 500-599 range, indicating a count
+        of internal server errors.
+        - ``response_time`: Alarms on the response time of HTTP requests. Threshold should be set in seconds.
+
+    :param name: The name of the the ``AlbAlarmGroup`` resource.
+    :type name: str
+
+    :param monitoring_group: The ``CloudWatchMonitoringGroup`` this alarm group belongs to.
+    :type monitoring_group: CloudWatchMonitoringGroup
+
+    :param project: The ``ThunderbirdPulumiProject`` being monitored.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param resource: The ``aws.lb.load_balancer.LoadBalancer`` being monitored.
+    :type resource: aws.lb.load_balancer.LoadBalancer
+
+    :param opts: Additional ``pulumi.ResourceOptions`` to apply to this resource. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+    """
+
     def __init__(
         self,
         name: str,
-        monitoring_group: tb_pulumi.monitoring.MonitoringGroup,
+        monitoring_group: CloudWatchMonitoringGroup,
         project: tb_pulumi.ThunderbirdPulumiProject,
-        resource: pulumi.Resource,
+        resource: aws.lb.load_balancer.LoadBalancer,
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
         super().__init__(
-            'tb:cloudwatch:AlbAlertGroup', name=name, project=project, resource=resource, opts=opts, **kwargs
-        )
-
-        fivexx_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 10}
-        fivexx_opts.update(self.overrides['fivexx'] if 'fivexx' in self.overrides else {})
-        fivexx = aws.cloudwatch.MetricAlarm(
-            f'{self.name}-5xx',
-            name=f'{self.project.name_prefix}-5xx',
-            comparison_operator='GreaterThanOrEqualToThreshold',
-            metric_name='HTTPCode_ELB_5XX_Count',
-            namespace='AWS/ApplicationELB',
-            alarm_description=f'Elevated 5xx errors on ALB {resource.name}',
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
-            **fivexx_opts,
-        )
-
-        response_time_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 1}
-        response_time_opts.update(self.overrides['response_time'] if 'response_time' in self.overrides else {})
-        response_time = aws.cloudwatch.MetricAlarm(
-            f'{self.name}-responsetime',
-            name=f'{self.project.name_prefix}-responsetime',
-            comparison_operator='GreaterThanOrEqualToThreshold',
-            metric_name='TargetResponseTime',
-            namespace='AWS/ApplicationELB',
-            alarm_description=f'Average response time is over {response_time_opts['threshold']} second(s) for {response_time_opts['period']} seconds',  # noqa: E501
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
-        )
-
-        self.finish(outputs={}, resources={'five_x_x': fivexx, 'response_time': response_time})
-
-
-class FargateServiceAlertGroup(tb_pulumi.monitoring.AlertGroup):
-    def __init__(
-        self,
-        name: str,
-        project: tb_pulumi.ThunderbirdPulumiProject,
-        resource: pulumi.Resource,
-        monitoring_group: tb_pulumi.monitoring.MonitoringGroup,
-        opts: pulumi.ResourceOptions = None,
-        **kwargs,
-    ):
-        super().__init__(
-            'tb:cloudwatch:FargateClusterAlertGroup',
+            pulumi_type='tb:cloudwatch:AlbAlarmGroup',
             name=name,
+            monitoring_group=monitoring_group,
             project=project,
             resource=resource,
-            monitoring_group=monitoring_group,
             opts=opts,
             **kwargs,
         )
 
-        cpu_utilization_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 80}
-        cpu_utilization_opts.update(self.overrides['cpu_utilization'] if 'cpu_utilization' in self.overrides else {})
-        cpu_utilization_desc = resource.name.apply(
-            lambda resource_name: f'CPU utilization on the {resource_name} service exceeds {cpu_utilization_opts['threshold']}%'  # noqa: E501
-        )
-        cpu_utilization_alarm = aws.cloudwatch.MetricAlarm(
-            f'{self.name}-cpu',
-            name=f'{self.project.name_prefix}-cpu',
-            comparison_operator='GreaterThanOrEqualToThreshold',
-            metric_name='CPUUtilization',
-            namespace='AWS/ECS',
-            alarm_description=cpu_utilization_desc,
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
-            **cpu_utilization_opts,
+        # Alert if we see sustained 5xx statuses
+        fivexx_opts = {'enabled': True, 'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 10}
+        fivexx_opts.update(self.overrides['fivexx'] if 'fivexx' in self.overrides else {})
+        fivexx_enabled = fivexx_opts['enabled']
+        del fivexx_opts['enabled']
+        fivexx = (
+            aws.cloudwatch.MetricAlarm(
+                f'{self.name}-5xx',
+                name=f'{self.project.name_prefix}-5xx',
+                comparison_operator='GreaterThanOrEqualToThreshold',
+                dimensions={'LoadBalancer': f'app/{resource.name}/{resource.arn_suffix}'},
+                metric_name='HTTPCode_ELB_5XX_Count',
+                namespace='AWS/ApplicationELB',
+                alarm_description=f'Elevated 5xx errors on ALB {resource.name}',
+                opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+                **fivexx_opts,
+            )
+            if fivexx_enabled
+            else None
         )
 
-        memory_utilization_opts = {'evaluation_periods': 2, 'period': 300, 'statistic': 'Average', 'threshold': 80}
+        # Alert if response time is elevated over time
+        response_time_opts = {
+            'enabled': True,
+            'evaluation_periods': 2,
+            'period': 300,
+            'statistic': 'Average',
+            'threshold': 1,
+        }
+        response_time_opts.update(self.overrides['response_time'] if 'response_time' in self.overrides else {})
+        response_time_enabled = response_time_opts['enabled']
+        del response_time_opts['enabled']
+        response_time = (
+            aws.cloudwatch.MetricAlarm(
+                f'{self.name}-responsetime',
+                name=f'{self.project.name_prefix}-responsetime',
+                comparison_operator='GreaterThanOrEqualToThreshold',
+                dimensions={'LoadBalancer': f'app/{resource.name}/{resource.arn_suffix}'},
+                metric_name='TargetResponseTime',
+                namespace='AWS/ApplicationELB',
+                alarm_description=f'Average response time is over {response_time_opts['threshold']} second(s) for {response_time_opts['period']} seconds',  # noqa: E501
+                opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+                **response_time_opts,
+            )
+            if response_time_enabled
+            else None
+        )
+
+        self.finish(outputs={}, resources={'fivexx': fivexx, 'response_time': response_time})
+
+
+class EcsServiceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
+    """A set of alarms for ECS services. Contains the following configurable alarms:
+
+        - ``cpu_utilization``: Alarms on the overall CPU usage of the entire service, all tasks combined. Threshold is a
+            percentage.
+        - ``memory_utilization``: Alarms on the overall memory usage of the entire service, all tasks combined.
+            Threshold is a percentage.
+
+    :param name: The name of the ``EcsServiceAlarmGroup`` resource.
+    :type name: str
+
+    :param project: The ``ThunderbirdPulumiProject`` being monitored.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param resource: The Pulumi resource being monitored.
+    :type resource: aws.ecs.Service
+
+    :param monitoring_group: The ``CloudWatchMonitoringGroup`` this is a member of.
+    :type monitoring_group: CloudWatchMonitoringGroup
+
+    :param opts: Additional ``pulumi.ResourceOptions`` to apply to this resource. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+    """
+
+    def __init__(
+        self,
+        name: str,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        resource: aws.ecs.Service,
+        monitoring_group: CloudWatchMonitoringGroup,
+        opts: pulumi.ResourceOptions = None,
+        **kwargs,
+    ):
+        super().__init__(
+            pulumi_type='tb:cloudwatch:EcsServiceAlarmGroup',
+            name=name,
+            monitoring_group=monitoring_group,
+            project=project,
+            resource=resource,
+            opts=opts,
+            **kwargs,
+        )
+
+        # Alert if we see overall elevated CPU consumption
+        cpu_utilization_opts = {
+            'enabled': True,
+            'evaluation_periods': 2,
+            'period': 300,
+            'statistic': 'Average',
+            'threshold': 80,
+        }
+        cpu_utilization_opts.update(self.overrides['cpu_utilization'] if 'cpu_utilization' in self.overrides else {})
+        cpu_utilization_enabled = cpu_utilization_opts['enabled']
+        del [cpu_utilization_opts['enabled']]
+        cpu_utilization_desc = resource.name.apply(
+            lambda resource_name: f'CPU utilization on the {resource_name} cluster exceeds {cpu_utilization_opts['threshold']}%'  # noqa: E501
+        )
+        cpu_utilization = (
+            aws.cloudwatch.MetricAlarm(
+                f'{self.name}-cpu',
+                name=f'{self.project.name_prefix}-cpu',
+                comparison_operator='GreaterThanOrEqualToThreshold',
+                dimensions={'ServiceName': resource.name},
+                metric_name='CPUUtilization',
+                namespace='AWS/ECS',
+                alarm_description=cpu_utilization_desc,
+                opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+                **cpu_utilization_opts,
+            )
+            if cpu_utilization_enabled
+            else None
+        )
+
+        # Alert if we see overall elevated memory consumption
+        memory_utilization_opts = {
+            'enabled': True,
+            'evaluation_periods': 2,
+            'period': 300,
+            'statistic': 'Average',
+            'threshold': 80,
+        }
         memory_utilization_opts.update(
             self.overrides['memory_utilization'] if 'memory_utilization' in self.overrides else {}
         )
+        memory_utilization_enabled = memory_utilization_opts['enabled']
+        del memory_utilization_opts['enabled']
         memory_utilization_desc = resource.name.apply(
             lambda resource_name: f'Memory utilization on the {resource_name} cluster exceeds {memory_utilization_opts['threshold']}%'  # noqa: E501
         )
-        memory_utilization = aws.cloudwatch.MetricAlarm(
-            f'{self.name}-memory',
-            name=f'{self.project.name_prefix}-memory',
-            comparison_operator='GreaterThanOrEqualToThreshold',
-            metric_name='MemoryUtilization',
-            namespace='AWS/ECS',
-            alarm_description=memory_utilization_desc,
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
-            **memory_utilization_opts,
+        memory_utilization = (
+            aws.cloudwatch.MetricAlarm(
+                f'{self.name}-memory',
+                name=f'{self.project.name_prefix}-memory',
+                comparison_operator='GreaterThanOrEqualToThreshold',
+                dimensions={'ServiceName': resource.name},
+                metric_name='MemoryUtilization',
+                namespace='AWS/ECS',
+                alarm_description=memory_utilization_desc,
+                opts=pulumi.ResourceOptions(parent=self, depends_on=[resource]),
+                **memory_utilization_opts,
+            )
+            if memory_utilization_enabled
+            else None
         )
 
         self.finish(
             outputs={},
-            resources={'cpu_utilization': cpu_utilization_alarm, 'memory_utilization': memory_utilization},
+            resources={'cpu_utilization': cpu_utilization, 'memory_utilization': memory_utilization},
         )

--- a/tb_pulumi/monitoring.py
+++ b/tb_pulumi/monitoring.py
@@ -98,8 +98,7 @@ class AlarmGroup(tb_pulumi.ThunderbirdComponentResource):
 
     @cached_property
     def overrides(self) -> dict:
-        """If the user has configured any overrides for alarms related to this resource, this function returns them.
-        """
+        """If the user has configured any overrides for alarms related to this resource, this function returns them."""
         if self.resource._name in self.monitoring_group.config['alarms'].keys():
             return self.monitoring_group.config['alarms'][self.resource._name]
         else:

--- a/tb_pulumi/monitoring.py
+++ b/tb_pulumi/monitoring.py
@@ -1,0 +1,39 @@
+"""Infrastructural patterns related to AWS CloudWatch."""
+
+import pulumi
+import tb_pulumi
+
+from functools import cached_property
+
+
+class MonitoringGroup(tb_pulumi.ThunderbirdComponentResource):
+    def __init__(
+        self,
+        pulumi_type: str,
+        name: str,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        config: dict = {},
+        opts: pulumi.ResourceOptions = None,
+    ):
+        super().__init__(pulumi_type=pulumi_type, name=name, project=project, opts=opts)
+        self.config = config
+
+
+class AlertGroup(tb_pulumi.ThunderbirdComponentResource):
+    def __init__(
+        self,
+        pulumi_type: str,
+        name: str,
+        monitoring_group: MonitoringGroup,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        resource: pulumi.Resource,
+        opts: pulumi.ResourceOptions = None,
+    ):
+        super().__init__(pulumi_type=pulumi_type, name=name, project=project, opts=opts)
+        self.monitoring_group = monitoring_group
+        self.resource = resource
+
+    @cached_property
+    def overrides(self):
+        if self.resource._name in self.monitoring_group.config['alarms'].keys():
+            return self.monitoring_group.config['alarms'][self.resource._name]

--- a/tb_pulumi/monitoring.py
+++ b/tb_pulumi/monitoring.py
@@ -1,4 +1,4 @@
-"""Infrastructural patterns related to AWS CloudWatch."""
+"""Common code related to monitoring patterns."""
 
 import pulumi
 import tb_pulumi
@@ -7,6 +7,44 @@ from functools import cached_property
 
 
 class MonitoringGroup(tb_pulumi.ThunderbirdComponentResource):
+    """A broad-scope approach to aggregate resource monitoring. A ``MonitoringGroup`` is a very thin class that should
+    be extended to provide specific monitoring solutions for the resources contained in the specified ``project``.
+
+    :param pulumi_type: The "type" string (commonly referred to in docs as just ``t``) of the component as described
+        by `Pulumi's docs <https://www.pulumi.com/docs/concepts/resources/names/#types>`_.
+    :type pulumi_type: str
+
+    :param name: The name of the ``MonitoringGroup`` resource.
+    :type name: str
+
+    :param project: The ``ThunderbirdPulumiProject`` to build monitoring resources for.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param config: A configuration dictionary. The specific format and content of this dictionary should be defined by
+        classes extending this class. The dictionary should be configured in roughly the following way:
+        ::
+
+            {
+                "alarms": {
+                    "name-of-the-resource-being-monitored": {
+                        "monitor_name": {
+                            "enabled": False
+                        }
+                    }
+                }
+            }
+
+        ``"alarms"`` should be a dictionary defining override settings for alarms. Its keys should be the names of
+        Pulumi resources being monitored, and their values should also be dictionaries. The alarm group will define
+        some alarms which can be tweaked. Refer to their documentation for details. All alarms should respond to a
+        boolean ``"enabled"`` value such that the alarm will not be created if this is ``False``. Beyond that, configure
+        each alarm as described in its alarm group documentation. Defaults to {}.
+    :type config: dict, optional
+
+    :param opts: Additional ``pulumi.ResourceOptions`` to apply to this resource. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+    """
+
     def __init__(
         self,
         pulumi_type: str,
@@ -19,7 +57,32 @@ class MonitoringGroup(tb_pulumi.ThunderbirdComponentResource):
         self.config = config
 
 
-class AlertGroup(tb_pulumi.ThunderbirdComponentResource):
+class AlarmGroup(tb_pulumi.ThunderbirdComponentResource):
+    """A collection of alarms set up to monitor a particular single resource. For example, there are multiple metrics to
+    alarm on pertaining to a load balancer. An ``AlarmGroup`` would collect all of those alarms under one object. This
+    class should be considered a base class for building more sophisticated alarm groups.
+
+    :param pulumi_type: The "type" string (commonly referred to in docs as just ``t``) of the component as described
+        by `Pulumi's docs <https://www.pulumi.com/docs/concepts/resources/names/#types>`_.
+    :type pulumi_type: str
+
+    :param name: The name of the ``AlarmGroup`` resource.
+    :type name: str
+
+    :param monitoring_group: The ``MonitoringGroup`` that this ``AlarmGroup`` belongs to. This is how configuration
+        overrides are delivered from the YAML config file to the individual alarm groups.
+    :type monitoring_group: MonitoringGroup
+
+    :param project: The ``ThunderbirdPulumiProject`` whose resources are being monitored.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param resource: The Pulumi ``Resource`` object this ``AlarmGroup`` is building alarms for.
+    :type resource: pulumi.Resource
+
+    :param opts: Additional ``pulumi.ResourceOptions`` to apply to this resource. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+    """
+
     def __init__(
         self,
         pulumi_type: str,
@@ -34,6 +97,10 @@ class AlertGroup(tb_pulumi.ThunderbirdComponentResource):
         self.resource = resource
 
     @cached_property
-    def overrides(self):
+    def overrides(self) -> dict:
+        """If the user has configured any overrides for alarms related to this resource, this function returns them.
+        """
         if self.resource._name in self.monitoring_group.config['alarms'].keys():
             return self.monitoring_group.config['alarms'][self.resource._name]
+        else:
+            return {}


### PR DESCRIPTION
## Description of the Change

This sets forth the model for building monitoring solutions which apply to entire projects.

## Benefits

Instead of writing code to build alarms for different types of resources (espcially since those resources are defined in this module and require research for end users to fully grok), this module allows you to just throw a project at a pre-defined monitoring solution and get a whole suite of monitoring setups with reasonable defaults automatically. Linting issues aside, this requires about 2 lines of code.

## Applicable Issues

Begins to solve #33. There's more work to be done here (going through each resource type and setting up monitoring for it), but that is a huge chunk of work that I'm going to tackle iteratively. This does set forth the model for doing all of that work, though, and I'd like to release it with v0.0.7.
