### PR TITLE
Overhaul CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -35,5 +35,37 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build docs
+        shell: bash
+        run: |
+          pip install .[dev]
+          cd docs
+          make clean html
+          cd _build/html/
+          tar -cvjf ../../../docs.tbz ./*
+
+      - name: Archive docs
+        id: archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: docs.tbz
+
+      - name: Publish docs
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages  # this is the default, but let's be explicit
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html/
+          force_orphan: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,7 +30,7 @@ jobs:
             docs:
               - 'docs/**'
 
-  # Build the documentation with both themes and publish to Github Pages
+  # Build the documentation and publish to Github Pages
   publish-docs:
     needs: detect-changes
     if: needs.detect-changes.outputs.docs == 'true'
@@ -48,9 +48,12 @@ jobs:
       - name: Build docs
         shell: bash
         run: |
+          # Install dependencies and build the HTML docs
           pip install .[dev]
           cd docs
           make clean html
+
+          # Compress for archival
           cd _build/html/
           tar -cvjf ../../../docs.tbz ./*
 
@@ -61,6 +64,7 @@ jobs:
           name: docs
           path: docs.tbz
 
+      # This publishes the built docs into a special git branch which we tell Github to use with Github Pages
       - name: Publish docs
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,39 @@
+---
+name: merge-main
+
+concurrency:
+  group: merge-main
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+    contents: read
+
+jobs:
+
+  # This job detects which parts of the repo have been changed, setting future jobs up for conditional behavior.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.check.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: check
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+
+  # Build the documentation with both themes and publish to Github Pages
+  publish-docs:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+---
+name: deploy-staging-and-create-release
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+on:
+  push:  # Fix: on release
+    branches:
+      - main
+
+permissions:
+    contents: read
+
+jobs:
+
+  # This job detects which parts of the repo have been changed, setting future jobs up for conditional behavior.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.check.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: check
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+
+  detect-versions:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      branch-exists: ${{ steps.branch-exists.outputs.exists }}
+      version: v${{ steps.version.outputs.value }}
+    steps:
+      # Detect version from pyproject.toml
+      - uses: actions/checkout@v4
+      - uses: SebRollen/toml-action@v1.2.0
+        id: version
+        with:
+          file: './pyproject.toml'
+          field: project.version
+      - uses: GuillaumeFalourd/branch-exists@v1
+        id: branch-exists
+        with:
+          branch: v${{ steps.version.outputs.value }}
+
+
+  # The below code is commented out because it works, except for a Github auth issue.
+  # Ref: https://github.com/orgs/community/discussions/13836
+
+  # When the PR gets merged, cut a new version branch.
+  # merge:
+  #   needs: detect-versions
+  #   if: github.event.pull_request.merged == true && needs.detect-versions.outputs.branch-exists == 'false'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - name: Create a new version branch
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       shell: bash
+  #       run: |
+  #         git checkout -b ${{ needs.detect-versions.outputs.version }}
+  #         git push -u origin ${{ needs.detect-versions.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,73 +1,63 @@
 ---
-name: deploy-staging-and-create-release
+name: release
 
 concurrency:
-  group: deploy-staging
+  group: release
   cancel-in-progress: true
 
-on:
-  push:  # Fix: on release
-    branches:
-      - main
+on: release
 
 permissions:
     contents: read
 
 jobs:
 
-  # This job detects which parts of the repo have been changed, setting future jobs up for conditional behavior.
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs: ${{ steps.check.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: check
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-
   detect-versions:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     outputs:
       branch-exists: ${{ steps.branch-exists.outputs.exists }}
       version: v${{ steps.version.outputs.value }}
     steps:
-      # Detect version from pyproject.toml
       - uses: actions/checkout@v4
+
+      # Detect version from pyproject.toml
       - uses: SebRollen/toml-action@v1.2.0
         id: version
         with:
           file: './pyproject.toml'
           field: project.version
+
       - uses: GuillaumeFalourd/branch-exists@v1
         id: branch-exists
         with:
           branch: v${{ steps.version.outputs.value }}
+
+      - name: Fail on branch conflict
+        if: steps.branch-exists.outputs.exists == 'true'
+        shell: bash
+        run: |
+            echo "ERROR: A branch already exists called v${{ steps.version.outputs.value }}"
+            echo "       Update package.json to refer to a new version."
+            exit 1
 
 
   # The below code is commented out because it works, except for a Github auth issue.
   # Ref: https://github.com/orgs/community/discussions/13836
 
   # When the PR gets merged, cut a new version branch.
-  # merge:
-  #   needs: detect-versions
-  #   if: github.event.pull_request.merged == true && needs.detect-versions.outputs.branch-exists == 'false'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #   steps:
-  #     - uses: actions/checkout@v4
+  merge:
+    needs: detect-versions
+    if: needs.detect-versions.outputs.branch-exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Create a new version branch
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       shell: bash
-  #       run: |
-  #         git checkout -b ${{ needs.detect-versions.outputs.version }}
-  #         git push -u origin ${{ needs.detect-versions.outputs.version }}
+      - name: Create a new version branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          git checkout -b ${{ needs.detect-versions.outputs.version }}
+          git push -u origin ${{ needs.detect-versions.outputs.version }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,18 +62,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-
-      - name: Install dependencies
-        run: |
-          pip install .[dev]
+      - name: Install Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Build docs
+        shell: bash
         run: |
+          # GHA does `set -e` for us, but we expect the grep below to fail. Thus, we must `set +e` here.
+          set +e
+          pip install .[dev]
           cd docs
-          make clean build |& tee make.log
+          make clean html |& tee make.log
           grep '\(ERROR\|WARNING\)' make.log
           if [ $? -eq 0 ]; then
             echo "Problems found in docs build"
             exit 1
+          else
+            exit 0
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,13 +1,4 @@
 ---
-# The general flow of this is like so:
-#
-# - When a PR is opened against `main`, or if that PR changes:
-#   - Figure out if any code changes have been made
-#   - Require a version number change
-#   - Require that the code pass Ruff tests
-# - When the PR gets merged:
-#   - Create a new branch matching the version number
-
 name: validate
 
 concurrency:
@@ -15,18 +6,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
-    types:
-      - opened
-      - edited
-      - synchronize
-      - closed
+      - '**'
+      - '!main'
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
 
@@ -34,7 +20,8 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      lint: ${{ steps.check.outputs.lint }}
+      docs: ${{ steps.check.outputs.docs }}
+      tb_pulumi: ${{ steps.check.outputs.tb_pulumi }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,36 +29,17 @@ jobs:
         id: check
         with:
           filters: |
-            lint:
+            tb_pulumi:
               - 'tb_pulumi/**'
               - 'pyproject.toml'
-
-  # This job detects what version is listed in pyproject.toml and determines if a branch exists for that version yet.
-  detect-versions:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.lint == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      branch-exists: ${{ steps.branch-exists.outputs.exists }}
-      version: v${{ steps.version.outputs.value }}
-    steps:
-      # Detect version from pyproject.toml
-      - uses: actions/checkout@v4
-      - uses: SebRollen/toml-action@v1.2.0
-        id: version
-        with:
-          file: './pyproject.toml'
-          field: project.version
-      - uses: GuillaumeFalourd/branch-exists@v1
-        id: branch-exists
-        with:
-          branch: v${{ steps.version.outputs.value }}
+            docs:
+              - 'docs/**'
 
   # Run Ruff against tb_pulumi. Fail on format errors or failed sanity checks.
   lint:
     needs: detect-changes
     runs-on: ubuntu-latest
-    if: needs.detect-changes.outputs.lint == 'true'
+    if: needs.detect-changes.outputs.tb_pulumi == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -86,23 +54,26 @@ jobs:
           src: './tb_pulumi'
           args: 'format --check'
 
-  # The below code is commented out because it works, except for a Github auth issue.
-  # Ref: https://github.com/orgs/community/discussions/13836
+  # Attempt to build the documentation. Fail if there are errors or warnings.
+  build_docs:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.docs == 'true'
+    steps:
+      - uses: actions/checkout@v4
 
-  # When the PR gets merged, cut a new version branch.
-  # merge:
-  #   needs: detect-versions
-  #   if: github.event.pull_request.merged == true && needs.detect-versions.outputs.branch-exists == 'false'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #   steps:
-  #     - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
 
-  #     - name: Create a new version branch
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       shell: bash
-  #       run: |
-  #         git checkout -b ${{ needs.detect-versions.outputs.version }}
-  #         git push -u origin ${{ needs.detect-versions.outputs.version }}
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
+
+      - name: Build docs
+        run: |
+          cd docs
+          make clean build |& tee make.log
+          grep '\(ERROR\|WARNING\)' make.log
+          if [ $? -eq 0 ]; then
+            echo "Problems found in docs build"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 build
+docs.tbz
 docs/_build
 docs/_doctrees
 docs/_static
 docs/_templates
+docs/make.log
 *.egg-info
 *.pyc
 __pycache__

--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -1,0 +1,7 @@
+tb\_pulumi.ci
+=====================
+
+.. automodule:: tb_pulumi.ci
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -217,7 +217,7 @@ def env_var_is_true(name: str) -> bool:
 
 
 def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource) -> set[pulumi.Resource]:
-    """Recursively traverses a nested collection of Pulumi ``Resource``s, converting them into a flat set which can be
+    """Recursively traverses a nested collection of Pulumi ``Resource`` s, converting them into a flat set which can be
     more easily iterated over.
 
     :param item: Either a Pulumi ``Resource`` object, or some collection thereof. The following types of collections are

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -224,7 +224,7 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource) 
         supported: ``dict``, ``list``, ``ThunderbirdComponentResource``.
     :type item: dict | list | ThunderbirdComponentResource
 
-    :return: A ``set`` of Pulumi ``Resource``s contained within the collection.
+    :return: A ``set`` of Pulumi ``Resource`` s contained within the collection.
     :rtype: set(pulumi.Resource)
     """
 

--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -42,7 +42,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
     :param forcibly_destroy_buckets: When True, the service bucket and logging bucket will both be forcibly emptied -
         all their contents **destroyed beyond recovery** - when the bucket resource is destroyed. This is dangerous, as
         it bypasses protections against data loss. Only enable this for volatile environments. Defaults to False.
-    :type forcibly_destroy_buckets bool, optional
+    :type forcibly_destroy_buckets: bool, optional
 
     :param origins: List of `DistributionOrigin
         <https://www.pulumi.com/registry/packages/aws/api-docs/cloudfront/distribution/#distributionorigin>`_ objects to

--- a/tb_pulumi/rds.py
+++ b/tb_pulumi/rds.py
@@ -36,8 +36,9 @@ class RdsDatabaseGroup(tb_pulumi.ThunderbirdComponentResource):
     :type vpc_id: str
 
     :param allocated_storage: GB of storage to allot to each instance. AWS may impose different minimum values for
-        this option depending on other storage options. Details are
-        `here <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html>`_. Defaults to 20.
+        this option depending on other storage options. Details are found in
+        `AWS RDS documentation <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html>`_. Defaults to
+        20.
     :type allocated_storage: int, optional
 
     :param auto_minor_version_upgrade: Allow RDS to upgrade the engine as long as it's only a minor version change,
@@ -83,8 +84,8 @@ class RdsDatabaseGroup(tb_pulumi.ThunderbirdComponentResource):
     :type engine_version: str, optional
 
     :param instance_class: One of the database sizes listed
-        `here <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html>`_. Defaults to
-        'db.t3.micro'.
+        `in these docs <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html>`_.
+        Defaults to 'db.t3.micro'.
     :type instance_class: str, optional
 
     :param internal: When True, if no sg_cidrs are set, allows ingress only from what `vpc_cidr` is set to. If False


### PR DESCRIPTION
This PR does a bunch of CI-related stuff:

  - There are now three distinct steps:
    1. When pushing a non-main branch, we run the linter as before, but now also attempt to build the documentation and fail if there are any issues.
    2. When a PR is merged to main, the documentation gets built and pushed to a special branch which I will later set up to be used with Github Pages. So in this way, we should always now have documentation for the main branch live on GHP! (This was a stretch goal, but I figured I'd throw it in since I probably won't circle back to this for a while.)
    3. When we publish a release, we check to see if a branch exists matching the version number in `pyproject.toml`. If there is, the release automation will fail and refuse to continue. Otherwise, it will cut a new branch for the release. (Side note: I am not actually sure if this step will work. There is a [known permissions issue](https://github.com/orgs/community/discussions/13836) with GHA that might cause this to fail since we protect these branches. On the other hand, pushing a *new* branch [as opposed to updating an existing branch] is a different set of permissions, so maybe it will? We will find out.)
  - Fixes a bunch of stuff with the docs themselves:
    - Actually linking to the CI docs I wrote before.
    - Fixing some errors picked up by the now-automated Sphinx build.
    - .gitignore updates to exclude some new artifacts