### PR TITLE
Use ReadTheDocs theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ author = 'Ryan Jung, et al'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx_rtd_theme']
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
@@ -25,7 +25,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'  # Clean, organized theme with dark and light modes
+html_theme = 'sphinx_rtd_theme'  # Classic ReadTheDocs theme
 
 # -- Override path to read our docstrings
 sys.path.insert(0, os.path.abspath('..'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dependencies = { file = ["requirements.txt"] }
 
 [project.optional-dependencies]
 dev = [
-    "furo",
     "ruff",
-    "sphinx"
+    "sphinx",
+    "sphinx_rtd_theme",
 ]
 
 # Ruff


### PR DESCRIPTION
This PR changes the documentation theme from [Furo](https://sphinx-themes.readthedocs.io/en/latest/sample-sites/furo/) to [ReadTheDocs](https://sphinx-themes.readthedocs.io/en/latest/sample-sites/sphinx-rtd-theme/).