### PR TITLE
Fix a number of issues related to project resource traversal

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,12 +48,14 @@ jobs:
         uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
+          version-file: "pyproject.toml"
 
       - name: Run Ruff linter
         uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
           args: 'format --check'
+          version-file: "pyproject.toml"
 
   # Attempt to build the documentation. Fail if there are errors or warnings.
   build_docs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,14 +48,12 @@ jobs:
         uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
-          version-file: "pyproject.toml"
 
       - name: Run Ruff linter
         uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
-          args: 'format --check'
-          version-file: "pyproject.toml"
+          args: 'format --check --diff'
 
   # Attempt to build the documentation. Fail if there are errors or warnings.
   build_docs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,12 +45,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Ruff syntax checks
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
 
       - name: Run Ruff linter
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           src: './tb_pulumi'
           args: 'format --check'

--- a/docs/monitors.rst
+++ b/docs/monitors.rst
@@ -8,7 +8,7 @@ can have complex structures with nested lists, dicts, and ``ThunderbirdComponent
 
 The ``monitoring`` module contains two base classes intended to provide common interfaces to building monitoring
 patterns. The first is a :py:class:`tb_pulumi.monitoring.MonitoringGroup`. This is a
-:py:class:`tb_pulumi.ThunderbirdComponentResource` which stores a configuration over overrides internally. It also
+:py:class:`tb_pulumi.ThunderbirdComponentResource` which stores a configuration of overrides internally. It also
 recursively unpacks and resolves any ``Output`` s in the resource stack. The purpose is twofold:
 
 - To contain and enumerate the resources which can be monitored that exist within the stack.

--- a/docs/monitors.rst
+++ b/docs/monitors.rst
@@ -4,17 +4,19 @@ When you use a ``ThunderbirdPulumiProject`` and add ``ThunderbirdComponentResour
 resources in an internal mapping correlating the name of the module to a collection of its resources. These resources
 can have complex structures with nested lists, dicts, and ``ThunderbirdComponentResource`` s. The project's
 :py:meth:`tb_pulumi.ThunderbirdPulumiProject.flatten` function returns these as a flat list of unlabeled Pulumi
-``Resource`` s.
+``Resource`` s and ``Output`` s.
 
 The ``monitoring`` module contains two base classes intended to provide common interfaces to building monitoring
-patterns. The first is a ``MonitoringGroup``. This is little more than a ``ThunderbirdComponentResource`` that contains
-a config dictionary. The purpose is to contain the resources involved in a monitoring solution. That is, alarms and a
-notification setup.
+patterns. The first is a :py:class:`tb_pulumi.monitoring.MonitoringGroup`. This is a
+:py:class:`tb_pulumi.ThunderbirdComponentResource` which stores a configuration over overrides internally. It also
+recursively unpacks and resolves any ``Output`` s in the resource stack. The purpose is twofold:
 
-You should extend this class such that the resources returned by ``flatten`` are iterated over. If your module
-understands that a resource it comes across can be monitored, the class should create alarms via an extension of the
-second class, ``AlarmGroup``. This base class should be extended such that it creates alarms for a specific single
-resource. For example, a single load balancer might have many different metrics being monitored.
+- To contain and enumerate the resources which can be monitored that exist within the stack.
+- To define the monitoring setup itself, including a method of notification.
+
+The second is a :py:class:`tb_pulumi.monitoring.AlarmGroup`. This class represents an overridable set of alarms for a
+single resource. ``MonitoringGroup`` s must map resource types to ``AlarmGroup`` types that handle those resources in
+their ``monitor`` functions.
 
 As an example, take a look at :py:class:`tb_pulumi.cloudwatch.CloudWatchMonitoringGroup`, a ``MonitoringGroup``
 extension that uses AWS CloudWatch to alarm on metrics produced by AWS resources. It creates an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,22 +32,3 @@ exclude = [
 
 # Always generate Python 3.12-compatible code.
 target-version = "py312"
-
-[tool.ruff.lint]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
-ignore = []
-
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-unfixable = []
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.ruff.lint.flake8-quotes]
-inline-quotes = "single"
-
-[tool.ruff.lint.mccabe]
-# Unlike Flake8, default to a complexity level of 10.
-max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,6 @@ dev = [
     "sphinx"
 ]
 
-# Ruff
-# [tool.ruff]
-# line-length = 120
-
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".eggs",
@@ -36,10 +32,6 @@ exclude = [
 
 # Always generate Python 3.12-compatible code.
 target-version = "py312"
-
-# [tool.ruff.format]
-# # Prefer single quotes over double quotes.
-# quote-style = "single"
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dev = [
 ]
 
 # Ruff
-[tool.ruff]
-line-length = 120
+# [tool.ruff]
+# line-length = 120
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -37,9 +37,9 @@ exclude = [
 # Always generate Python 3.12-compatible code.
 target-version = "py312"
 
-[tool.ruff.format]
-# Prefer single quotes over double quotes.
-quote-style = "single"
+# [tool.ruff.format]
+# # Prefer single quotes over double quotes.
+# quote-style = "single"
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<44.0
 pulumi>=3.130.0,<4.0.0
-pulumi-aws==6.57.0
+pulumi-aws==6.65.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<44.0
-pulumi==3.145.0
+pulumi>=3.130.0,<4.0.0
 pulumi-aws==6.65.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<44.0
-pulumi>=3.130.0,<4.0.0
+pulumi==3.145.0
 pulumi-aws==6.65.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+line-length = 120
+
+[format]
+quote-style = "single"

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,3 +2,22 @@ line-length = 120
 
 [format]
 quote-style = "single"
+
+[lint]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+
+[lint.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -136,8 +136,7 @@ class ThunderbirdComponentResource(pulumi.ComponentResource):
 
         if self.protect_resources:
             pulumi.info(
-                f'Resource protection has been enabled on {name}. '
-                'To disable, export TBPULUMI_DISABLE_PROTECTION=True'
+                f'Resource protection has been enabled on {name}. To disable, export TBPULUMI_DISABLE_PROTECTION=True'
             )
 
         # Merge provided opts with defaults before calling superconstructor

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -246,9 +246,9 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
     if type(item) is list:
         to_flatten = item
     elif type(item) is dict:
-        to_flatten = item.values()
+        to_flatten = set(item.values())
     elif isinstance(item, ThunderbirdComponentResource):
-        to_flatten = item.resources.values()
+        to_flatten = set(item.resources.values())
     elif isinstance(item, pulumi.Resource) or isinstance(item, pulumi.Output):
         return [item]
     else:

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -261,10 +261,7 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
 
     if to_flatten is not None:
         for item in to_flatten:
-            if isinstance(item, pulumi.Output):
-                item.apply(lambda i: flattened.extend(flatten(i)))
-            else:
-                flattened.extend(flatten(item))
+            flattened.extend(flatten(item))
 
-    pulumi.info(f'FLATTENED: {set(flattened)}')
+    # pulumi.info(f'FLATTENED: {set(flattened)}')
     return set(flattened)

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -246,9 +246,9 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
     if type(item) is list:
         to_flatten = item
     elif type(item) is dict:
-        to_flatten = set(item.values())
+        to_flatten = item.values()
     elif isinstance(item, ThunderbirdComponentResource):
-        to_flatten = set(item.resources.values())
+        to_flatten = item.resources.values()
     elif isinstance(item, pulumi.Resource) or isinstance(item, pulumi.Output):
         return [item]
 

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -233,12 +233,13 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource) 
     # a flat list first, then operate on its items.
     flattened = []
     to_flatten = None
+    pulumi.info(f'Flattening item: {item}')
     if type(item) is list:
         to_flatten = item
     elif type(item) is dict:
-        to_flatten = [value for _, value in item.items()]
+        to_flatten = item.values()
     elif isinstance(item, ThunderbirdComponentResource):
-        to_flatten = [value for _, value in item.resources.items()]
+        to_flatten = item.resources.values()
     elif isinstance(item, pulumi.Resource):
         return [item]
     else:

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -90,6 +90,7 @@ class ThunderbirdPulumiProject:
     def flatten(self) -> set[pulumi.Resource]:
         """Returns a flat set of all resources existing within this project."""
 
+        pulumi.info(f'FLATTENING RESOURCES: {self.resources.keys()}')
         return flatten(self.resources)
 
 
@@ -233,14 +234,17 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Resource) 
     # a flat list first, then operate on its items.
     flattened = []
     to_flatten = None
-    pulumi.info(f'Flattening item: {item}')
     if type(item) is list:
+        pulumi.info(f'FOUND LIST: {item}')
         to_flatten = item
     elif type(item) is dict:
+        pulumi.info(f'FOUND DICT: {item}')
         to_flatten = item.values()
     elif isinstance(item, ThunderbirdComponentResource):
+        pulumi.info(f'FOUND TCR: {item._name} -> {item.resources.values()}')
         to_flatten = item.resources.values()
     elif isinstance(item, pulumi.Resource):
+        pulumi.info(f'FOUND RESOURCE: {item._name}, {str(item.__class__)}')
         return [item]
     else:
         pass

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -244,16 +244,12 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
     flattened = []
     to_flatten = None
     if type(item) is list:
-        # pulumi.info(f'FOUND LIST: {item}')
         to_flatten = item
     elif type(item) is dict:
-        # pulumi.info(f'FOUND DICT: {item}')
         to_flatten = item.values()
     elif isinstance(item, ThunderbirdComponentResource):
-        # pulumi.info(f'FOUND TCR: {item._name} -> {item.resources.values()}')
         to_flatten = item.resources.values()
     elif isinstance(item, pulumi.Resource) or isinstance(item, pulumi.Output):
-        # pulumi.info(f'FOUND RESOURCE: {item._name}, {str(item.__class__)}')
         return [item]
     else:
         pass
@@ -262,5 +258,4 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
         for item in to_flatten:
             flattened.extend(flatten(item))
 
-    # pulumi.info(f'FLATTENED: {set(flattened)}')
     return set(flattened)

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -90,7 +90,6 @@ class ThunderbirdPulumiProject:
     def flatten(self) -> set[pulumi.Resource]:
         """Returns a flat set of all resources existing within this project."""
 
-        pulumi.info(f'FLATTENING RESOURCES: {self.resources.keys()}')
         return flatten(self.resources)
 
 

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -251,8 +251,6 @@ def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | p
         to_flatten = set(item.resources.values())
     elif isinstance(item, pulumi.Resource) or isinstance(item, pulumi.Output):
         return [item]
-    else:
-        pass
 
     if to_flatten is not None:
         for item in to_flatten:

--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -52,6 +52,9 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
 
     :param opts: Additional pulumi.ResourceOptions to apply to these resources. Defaults to None.
     :type opts: pulumi.ResourceOptions, optional
+
+    :param kwargs: Any other keyword arguments which will be passed as inputs to the ``ThunderbirdComponentResource``
+        resource.
     """
 
     def __init__(
@@ -68,7 +71,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-        super().__init__('tb:cloudfront:CloudFrontS3Service', name=name, project=project, opts=opts)
+        super().__init__('tb:cloudfront:CloudFrontS3Service', name=name, project=project, opts=opts, **kwargs)
 
         # The function supports supplying the bucket policy at this time, but we have to have the CF distro built first.
         # For this reason, we build the bucket without the policy and attach the policy later on.

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -76,7 +76,7 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         # The next two lines are useful for debugging monitoring setups since that logic depends largely on obscure
         # class names. These will show all resources and their classes in a project as well as a filtered list of
         # those resources correctly detected by the logic above.
-        # pulumi.info(f'All resources: {'\n'.join([str(res.__class__) for res in self.project.flatten()])}')
+        # pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}')
         # pulumi.info(f'Supported resources: {supported_resources}')
         for res in supported_resources:
             shortname = res._name.replace(f'{self.project.name_prefix}-', '')  # Make this name shorter, less redundant

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -223,13 +223,13 @@ class AlbAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         alb_5xx = pulumi.Output.all(res_name=resource.name, res_suffix=resource.arn_suffix).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-alb5xx',
-                name=f'{outputs['res_name']}-alb5xx',
+                name=f'{outputs["res_name"]}-alb5xx',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 dimensions={'LoadBalancer': outputs['res_suffix']},
                 metric_name='HTTPCode_ELB_5XX_Count',
                 namespace='AWS/ApplicationELB',
-                alarm_description=f'Elevated 5xx errors on ALB {outputs['res_name']}',
+                alarm_description=f'Elevated 5xx errors on ALB {outputs["res_name"]}',
                 tags=alb_5xx_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -251,13 +251,13 @@ class AlbAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         target_5xx = pulumi.Output.all(res_name=resource.name, res_suffix=resource.arn_suffix).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-target5xx',
-                name=f'{outputs['res_name']}-target5xx',
+                name=f'{outputs["res_name"]}-target5xx',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 dimensions={'LoadBalancer': outputs['res_suffix']},
                 metric_name='HTTPCode_ELB_5XX_Count',
                 namespace='AWS/ApplicationELB',
-                alarm_description=f'Elevated 5xx errors on the targets of ALB {outputs['res_name']}',
+                alarm_description=f'Elevated 5xx errors on the targets of ALB {outputs["res_name"]}',
                 tags=target_5xx_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -279,13 +279,13 @@ class AlbAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         response_time = pulumi.Output.all(res_name=resource.name, res_suffix=resource.arn_suffix).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-responsetime',
-                name=f'{outputs['res_name']}-responsetime',
+                name=f'{outputs["res_name"]}-responsetime',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 dimensions={'LoadBalancer': outputs['res_suffix']},
                 metric_name='TargetResponseTime',
                 namespace='AWS/ApplicationELB',
-                alarm_description=f'Average response time is over {response_time_opts['threshold']} second(s) for {response_time_opts['period']} seconds',  # noqa: E501
+                alarm_description=f'Average response time is over {response_time_opts["threshold"]} second(s) for {response_time_opts["period"]} seconds',  # noqa: E501
                 tags=response_time_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -401,14 +401,14 @@ class AlbTargetGroupAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         return pulumi.Output.all(tg_suffix=tg_suffix, lb_suffix=lb_suffix).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-unhealthy-hosts',
-                name=f'{outputs['tg_suffix'].split('/')[1]}-{outputs['lb_suffix'].split('/')[1]}-unhealthy-hosts',
+                name=f'{outputs["tg_suffix"].split("/")[1]}-{outputs["lb_suffix"].split("/")[1]}-unhealthy-hosts',
                 alarm_actions=[self.monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 dimensions={'TargetGroup': outputs['tg_suffix'], 'LoadBalancer': outputs['lb_suffix']},
                 metric_name='UnHealthyHostCount',
                 namespace='AWS/ApplicationELB',
-                alarm_description=f'{outputs['tg_suffix'].split('/')[1]} has detected unhealthy hosts in load balancer '
-                f'{outputs['lb_suffix'].split('/')[1]}',
+                alarm_description=f'{outputs["tg_suffix"].split("/")[1]} has detected unhealthy hosts in load balancer '
+                f'{outputs["lb_suffix"].split("/")[1]}',
                 tags=tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[target_group, self.monitoring_group.resources['sns_topic']]
@@ -474,14 +474,14 @@ class CloudFrontDistributionAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         distro_4xx = pulumi.Output.all(res_id=resource.id, res_comment=resource.comment).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-4xx',
-                name=f'{self.project.name_prefix}-cfdistro-{outputs['res_id']}-4xx',
+                name=f'{self.project.name_prefix}-cfdistro-{outputs["res_id"]}-4xx',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 dimensions={'DistributionId': outputs['res_id']},
                 metric_name='4xxErrorRate',
                 namespace='AWS/CloudFront',
-                alarm_description=f'4xx error rate for CloudFront Distribution "{outputs['res_comment']}" exceeds '
-                f'{distro_4xx_opts['threshold']} on average over {distro_4xx_opts['period']} seconds.',
+                alarm_description=f'4xx error rate for CloudFront Distribution "{outputs["res_comment"]}" exceeds '
+                f'{distro_4xx_opts["threshold"]} on average over {distro_4xx_opts["period"]} seconds.',
                 tags=distro_4xx_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -559,7 +559,7 @@ class CloudFrontFunctionAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
                     metric_name='FunctionComputeUtilization',
                     namespace='AWS/CloudFront',
                     alarm_description=f'CPU utilization on CloudFront Function {res_name} exceeds '
-                    f'{cpu_utilization_opts['threshold']}.',
+                    f'{cpu_utilization_opts["threshold"]}.',
                     tags=cpu_utilization_tags,
                     opts=pulumi.ResourceOptions(
                         parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -632,7 +632,7 @@ class EcsServiceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         cpu_utilization = pulumi.Output.all(res_name=resource.name, cluster_arn=resource.cluster).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-cpu',
-                name=f'{outputs['res_name']}-cpu',
+                name=f'{outputs["res_name"]}-cpu',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 # There is no direct way to get the Cluster name from a Service, but we can get the ARN, which has the
@@ -640,8 +640,8 @@ class EcsServiceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
                 dimensions={'ClusterName': outputs['cluster_arn'].split('/')[-1], 'ServiceName': outputs['res_name']},
                 metric_name='CPUUtilization',
                 namespace='AWS/ECS',
-                alarm_description=f'CPU utilization on the {outputs['res_name']} cluster exceeds '
-                f'{cpu_utilization_opts['threshold']}%',
+                alarm_description=f'CPU utilization on the {outputs["res_name"]} cluster exceeds '
+                f'{cpu_utilization_opts["threshold"]}%',
                 tags=cpu_utilization_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]
@@ -665,7 +665,7 @@ class EcsServiceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         memory_utilization = pulumi.Output.all(res_name=resource.name, cluster_arn=resource.cluster).apply(
             lambda outputs: aws.cloudwatch.MetricAlarm(
                 f'{self.name}-memory',
-                name=f'{outputs['res_name']}-memory',
+                name=f'{outputs["res_name"]}-memory',
                 alarm_actions=[monitoring_group.resources['sns_topic'].arn],
                 comparison_operator='GreaterThanOrEqualToThreshold',
                 # There is no direct way to get the Cluster name from a Service, but we can get the ARN, which has the
@@ -673,8 +673,8 @@ class EcsServiceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
                 dimensions={'ClusterName': outputs['cluster_arn'].split('/')[-1], 'ServiceName': outputs['res_name']},
                 metric_name='MemoryUtilization',
                 namespace='AWS/ECS',
-                alarm_description=f'Memory utilization on the {outputs['res_name']} cluster exceeds '
-                f'{memory_utilization_opts['threshold']}%',
+                alarm_description=f'Memory utilization on the {outputs["res_name"]} cluster exceeds '
+                f'{memory_utilization_opts["threshold"]}%',
                 tags=memory_utilization_tags,
                 opts=pulumi.ResourceOptions(
                     parent=self, depends_on=[resource, monitoring_group.resources['sns_topic']]

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -76,7 +76,7 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         # The next two lines are useful for debugging monitoring setups since that logic depends largely on obscure
         # class names. These will show all resources and their classes in a project as well as a filtered list of
         # those resources correctly detected by the logic above.
-        # pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}')
+        # pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}') # noqa: E501
         # pulumi.info(f'Supported resources: {supported_resources}')
         for res in supported_resources:
             shortname = res._name.replace(f'{self.project.name_prefix}-', '')  # Make this name shorter, less redundant

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -50,8 +50,11 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
             aws.cloudfront.Function: CloudFrontFunctionAlarmGroup,
             aws.ecs.Service: EcsServiceAlarmGroup,
         }
+        
+        # Sometimes monitorable resources appear as outputs that we have to wait on resolution for; split them off
+        project_resources = self.project.flatten()
         supported_resources = [
-            resource for resource in self.project.flatten() if type(resource) in supported_types.keys()
+            resource for resource in project_resources if type(resource) in supported_types.keys()
         ]
 
         sns_topic = aws.sns.Topic(
@@ -76,8 +79,8 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         # The next two lines are useful for debugging monitoring setups since that logic depends largely on obscure
         # class names. These will show all resources and their classes in a project as well as a filtered list of
         # those resources correctly detected by the logic above.
-        pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}') # noqa: E501
-        pulumi.info(f'Supported resources: {supported_resources}')
+        # pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}') # noqa: E501
+        # pulumi.info(f'Supported resources: {supported_resources}')
         for res in supported_resources:
             shortname = res._name.replace(f'{self.project.name_prefix}-', '')  # Make this name shorter, less redundant
             alarms[res._name] = supported_types[type(res)](

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -76,8 +76,8 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         # The next two lines are useful for debugging monitoring setups since that logic depends largely on obscure
         # class names. These will show all resources and their classes in a project as well as a filtered list of
         # those resources correctly detected by the logic above.
-        # pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}') # noqa: E501
-        # pulumi.info(f'Supported resources: {supported_resources}')
+        pulumi.info(f'All resources: {'\n'.join([f'{res._name}: {str(res.__class__)}' for res in self.project.flatten()])}') # noqa: E501
+        pulumi.info(f'Supported resources: {supported_resources}')
         for res in supported_resources:
             shortname = res._name.replace(f'{self.project.name_prefix}-', '')  # Make this name shorter, less redundant
             alarms[res._name] = supported_types[type(res)](

--- a/tb_pulumi/ec2.py
+++ b/tb_pulumi/ec2.py
@@ -69,7 +69,7 @@ class NetworkLoadBalancer(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-        super().__init__('tb:ec2:NetworkLoadBalancer', name, project, opts=opts)
+        super().__init__('tb:ec2:NetworkLoadBalancer', name=name, project=project, opts=opts)
 
         # The primary_subnet is just the first subnet listed, used for determining VPC placement
         primary_subnet = subnets[0]
@@ -77,7 +77,7 @@ class NetworkLoadBalancer(tb_pulumi.ThunderbirdComponentResource):
         # Build a security group that allows ingress on our listener port
         security_group_with_rules = tb_pulumi.network.SecurityGroupWithRules(
             f'{name}-sg',
-            project,
+            project=project,
             vpc_id=primary_subnet.vpc_id,
             rules={
                 'ingress': [

--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -259,6 +259,7 @@ class FargateClusterWithLogging(tb_pulumi.ThunderbirdComponentResource):
             fsalb_name,
             project,
             subnets=subnets,
+            exclude_from_project=True,
             internal=internal,
             security_groups=security_groups,
             services=services,

--- a/tb_pulumi/monitoring.py
+++ b/tb_pulumi/monitoring.py
@@ -146,7 +146,7 @@ class MonitoringGroup(tb_pulumi.ThunderbirdComponentResource):
 
         # From this side of an apply, we can see the resource types and look for ones we know about
         self.supported_resources = [res for res in self.all_resources if type(res) in self.type_map.keys()]
-        
+
         # Call downstream monitoring setups
         self.monitor(outputs)
 

--- a/tb_pulumi/network.py
+++ b/tb_pulumi/network.py
@@ -323,7 +323,7 @@ class SecurityGroupWithRules(tb_pulumi.ThunderbirdComponentResource):
             rule.update({'type': 'ingress', 'security_group_id': sg.id})
             ingress_rules.append(
                 aws.ec2.SecurityGroupRule(
-                    f'{name}-ingress-{rule['to_port']}',
+                    f'{name}-ingress-{rule["to_port"]}',
                     opts=pulumi.ResourceOptions(parent=self, depends_on=[sg]),
                     **rule,
                 )
@@ -334,7 +334,7 @@ class SecurityGroupWithRules(tb_pulumi.ThunderbirdComponentResource):
             rule.update({'type': 'egress', 'security_group_id': sg.id})
             egress_rules.append(
                 aws.ec2.SecurityGroupRule(
-                    f'{name}-egress-{rule['to_port']}',
+                    f'{name}-egress-{rule["to_port"]}',
                     opts=pulumi.ResourceOptions(parent=self, depends_on=[sg]),
                     **rule,
                 )

--- a/tb_pulumi/network.py
+++ b/tb_pulumi/network.py
@@ -179,6 +179,7 @@ class MultiCidrVpc(tb_pulumi.ThunderbirdComponentResource):
                 f'{name}-endpoint-sg',
                 project,
                 vpc_id=vpc.id,
+                exclude_from_project=True,
                 rules={
                     'ingress': [
                         {

--- a/tb_pulumi/rds.py
+++ b/tb_pulumi/rds.py
@@ -411,22 +411,23 @@ class RdsDatabaseGroup(tb_pulumi.ThunderbirdComponentResource):
         # Figure out the IPs once the instances are ready and build a load balancer targeting them
         port = SERVICE_PORTS.get(engine, 5432)
         inst_addrs = [instance.address for instance in instances]
-        load_balancer_ips = pulumi.Output.all(*inst_addrs).apply(
-            lambda addresses: [socket.gethostbyname(addr) for addr in addresses]
-        )
-        load_balancer = tb_pulumi.ec2.NetworkLoadBalancer(
-            f'{name}-nlb',
-            project=project,
-            exclude_from_project=True,
-            listener_port=port,
-            subnets=subnets,
-            target_port=port,
-            ingress_cidrs=[vpc_cidr],
-            internal=True,
-            ips=load_balancer_ips,
-            security_group_description=f'Allow database traffic for {name}',
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[*instances, *subnets]),
-        )
+
+        def __load_balancer(ips):
+            return tb_pulumi.ec2.NetworkLoadBalancer(
+                f'{name}-nlb',
+                project=project,
+                exclude_from_project=True,
+                listener_port=port,
+                subnets=subnets,
+                target_port=port,
+                ingress_cidrs=[vpc_cidr],
+                internal=True,
+                ips=ips,
+                security_group_description=f'Allow database traffic for {name}',
+                opts=pulumi.ResourceOptions(parent=self, depends_on=[*instances, *subnets]),
+            )
+
+        load_balancer = pulumi.Output.all(*inst_addrs).apply(lambda ips: __load_balancer(ips))
 
         ssm_param_db_read_host = load_balancer.apply(
             lambda lb: aws.ssm.Parameter(

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -17,6 +17,11 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
     :param project: The ThunderbirdPulumiProject to add these resources to.
     :type project: ThunderbirdPulumiProject
 
+    :param exclude_from_project: When ``True`` , this prevents this component resource from being registered directly
+        with the project. This does not prevent the component resource from being discovered by the project's
+        ``flatten`` function, provided that it is nested within some resource that is not excluded from the project.
+    :type exclude_from_project: bool, optional
+
     :param secret_name: A slash ("/") delimited name for the secret in AWS. The last segment of this will be used as the
         "short name" for abbreviated references.
     :type name: str
@@ -28,6 +33,10 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
     :param opts: Additional pulumi.ResourceOptions to apply to these resources. Defaults to None.
     :type opts: pulumi.ResourceOptions, optional
 
+    :param tags: Key/value pairs to merge with the default tags which get applied to all resources in this group.
+        Defaults to {}.
+    :type tags: dict, optional
+
     :param kwargs: Any other keyword arguments which will be passed as inputs to the ``aws.secretsmanager.Secret``
         resource.
     """
@@ -38,10 +47,19 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         project: tb_pulumi.ThunderbirdPulumiProject,
         secret_name: str,
         secret_value: typing.Any,
+        exclude_from_project: bool = False,
         opts: pulumi.ResourceOptions = None,
+        tags: dict = {},
         **kwargs,
     ):
-        super().__init__('tb:secrets:SecretsManagerSecret', name, project, opts=opts)
+        super().__init__(
+            'tb:secrets:SecretsManagerSecret',
+            name,
+            project,
+            exclude_from_project=exclude_from_project,
+            opts=opts,
+            tags=tags,
+        )
 
         secret = aws.secretsmanager.Secret(
             f'{name}-secret', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
@@ -104,6 +122,7 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
                 project=self.project,
                 secret_name=secret_fullname,
                 secret_value=secret_string,
+                exclude_from_project=True,
                 opts=pulumi.ResourceOptions(parent=self),
                 **kwargs,
             )

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -62,7 +62,7 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         )
 
         secret = aws.secretsmanager.Secret(
-            f'{name}-secret', opts=pulumi.ResourceOptions(parent=self), name=secret_name, **kwargs
+            f'{name}-secret', opts=pulumi.ResourceOptions(parent=self), name=secret_name, tags=self.tags, **kwargs
         )
 
         version = aws.secretsmanager.SecretVersion(
@@ -105,9 +105,10 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
         project: tb_pulumi.ThunderbirdPulumiProject,
         secret_names: list[str] = [],
         opts: pulumi.ResourceOptions = None,
+        tags: dict = {},
         **kwargs,
     ):
-        super().__init__('tb:secrets:PulumiSecretsManager', name, project, opts=opts)
+        super().__init__('tb:secrets:PulumiSecretsManager', name, project, opts=opts, tags=tags)
         secrets = []
 
         # First build the secrets
@@ -124,6 +125,7 @@ class PulumiSecretsManager(tb_pulumi.ThunderbirdComponentResource):
                 secret_value=secret_string,
                 exclude_from_project=True,
                 opts=pulumi.ResourceOptions(parent=self),
+                tags=self.tags,
                 **kwargs,
             )
             secrets.append(secret)


### PR DESCRIPTION
This PR addresses a few main issues.

1. #70: When volatile environments using the RDS module are rebuilt, you run into Secrets Manager clobbers. This PR allows you to optionally change the retention period on those secrets to prevent this issue in some environments while allowing the protection of this retention feature in others.
2. #71: Resources hidden by Pulumi Output objects do not get enumerated properly by monitoring groups.
3. #72: When ThunderbirdComponentResources register their resources with the project, it can cause namespace pollution.
4. Updates the AWS provider.

The issues have much more detail about the problems than I've listed here. A good chunk of this is corresponding documentation updates.