### PR TITLE
Set up custom Flattenable type

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -17,6 +17,7 @@ from typing import Any
 #: Type alias representing valid types to be found among a ThunderbirdPulumiProject's resources
 type Flattenable = dict | list | ThunderbirdComponentResource | pulumi.Output | pulumi.Resource
 
+
 class ThunderbirdPulumiProject:
     """A collection of related Pulumi resources upon which we can take bulk/collective actions. This class enforces some
     usage conventions that help keep us organized and consistent.

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -14,6 +14,7 @@ from tb_pulumi.constants import DEFAULT_PROTECTED_STACKS
 from typing import Any
 
 
+#: Type alias representing valid types to be found among a ThunderbirdPulumiProject's resources
 type Flattenable = dict | list | ThunderbirdComponentResource | pulumi.Output | pulumi.Resource
 
 class ThunderbirdPulumiProject:
@@ -232,8 +233,8 @@ def flatten(item: Flattenable) -> set[pulumi.Resource]:
     """Recursively traverses a nested collection of Pulumi ``Resource`` s, converting them into a flat set which can be
     more easily iterated over.
 
-    :param item: Either a Pulumi ``Resource`` object, or some collection thereof. The following types of collections are
-        supported: ``dict``, ``list``, ``ThunderbirdComponentResource``.
+    :param item: An item which we intend to flatten. Must be one of the recognized types or collections defined in
+        the Flattenable type alias.
     :type item: dict | list | ThunderbirdComponentResource
 
     :return: A ``set`` of Pulumi ``Resource`` s contained within the collection.

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -14,6 +14,8 @@ from tb_pulumi.constants import DEFAULT_PROTECTED_STACKS
 from typing import Any
 
 
+type Flattenable = dict | list | ThunderbirdComponentResource | pulumi.Output | pulumi.Resource
+
 class ThunderbirdPulumiProject:
     """A collection of related Pulumi resources upon which we can take bulk/collective actions. This class enforces some
     usage conventions that help keep us organized and consistent.
@@ -226,7 +228,7 @@ def env_var_is_true(name: str) -> bool:
     return env_var_matches(name, ['t', 'true', 'yes'], False)
 
 
-def flatten(item: dict | list | ThunderbirdComponentResource | pulumi.Output | pulumi.Resource) -> set[pulumi.Resource]:
+def flatten(item: Flattenable) -> set[pulumi.Resource]:
     """Recursively traverses a nested collection of Pulumi ``Resource`` s, converting them into a flat set which can be
     more easily iterated over.
 

--- a/tb_pulumi/monitoring.py
+++ b/tb_pulumi/monitoring.py
@@ -85,7 +85,7 @@ class MonitoringGroup(tb_pulumi.ThunderbirdComponentResource):
         self.supported_resources = []
 
         def __parse_resource_item(
-            item: list | dict | pulumi.Output | pulumi.Resource | tb_pulumi.ThunderbirdComponentResource,
+            item: tb_pulumi.Flattenable,
         ):
             """Not all items in a project's ``resources`` dict are actually Pulumi Resources. Sometimes we build
             resources downstream of a Pulumi Output, which makes those resources (as they are known to the project)


### PR DESCRIPTION
This is a small bit of housekeeping. We have a couple places we allow the same odd assortment of types, so I've consolidated them here under a custom type according to the [Python type alias docs](https://docs.python.org/3/library/typing.html#type-aliases). Ref: Issue #84.