### PR TITLE
Add some CloudWatch permissions for Fargate deploys

### DIFF
--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -261,6 +261,9 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                             'Sid': 'GlobalObjectReadAccess',
                             'Effect': 'Allow',
                             'Action': [
+                                'cloudwatch:Describe*',
+                                'cloudwatch:List*',
+                                'cloudwatch:TagResource',
                                 'ec2:List*',
                                 'ec2:Get*',
                                 'ec2:Describe*',


### PR DESCRIPTION
CI for send-suite fails without these permissions. This is because the CI steps that deploy new container images run Pulumi with both `--target` (to specify the task definition where the image is set) and `--target-dependents` (so the service using that task definition also gets updated to use it). However, monitors for the cluster/service are also dependent, and we have to grant a little bit of permission for Pulumi to read that data and update tags once in a while.