### PR TITLE
Fix this path to the artifact being archived

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -38,7 +38,7 @@ jobs:
 
           # Compress for archival
           cd _build/html
-          tar -cvjf ../../docs.tbz ./*
+          tar -cvjf ../../../docs.tbz ./*
 
       - name: Archive docs
         id: archive


### PR DESCRIPTION
This ought to fix the warning on [this workflow run](https://github.com/thunderbird/pulumi/actions/runs/13038669605) where the artifact is not present to be archived.