### PR TITLE
Provide a way to get the latest Amazon Linux AMI

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -132,7 +132,7 @@ class ThunderbirdPulumiProject:
             Defaults to `amzn2-ami-hvm-x86_64-gp2`.
         :type name_alias: str, optional
         """
-    
+
         ssm = self.get_aws_client(service='ssm', region_name=region_name)
         param = ssm.get_parameter(
             Name=f'/aws/service/ami-amazon-linux-latest/{name_alias}',

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -98,11 +98,8 @@ class ThunderbirdPulumiProject:
         :type region_name: str
         """
 
-        # Don't use "None" as part of the key; use "default" instead
-        if region_name is None:
-            key = f'{service}-default'
-        else:
-            key = f'{service}-{region_name}'
+        # Don't use "None" as part of the key; use the default for the project instead
+        key = f'{service}-{self.aws_region}' if region_name is None else f'{service}-{region_name}'
 
         # If there isn't a client for this service/region, build one
         if key not in self.__aws_clients.keys():

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -123,9 +123,9 @@ class ThunderbirdPulumiProject:
 
             .. code-block:: bash
 
-                aws ssm describe-parameters \
-                    --region eu-central-1 \
-                    --filters 'Key=Name,Values=/aws/service/ami-amazon-linux-latest/' \
+                aws ssm describe-parameters \\
+                    --region $your_region_here \\
+                    --filters 'Key=Name,Values=/aws/service/ami-amazon-linux-latest/' \\
                     --query 'Parameters[*].Name' |
                     sed 's/\/aws\/service\/ami-amazon-linux-latest\///g'
 

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -108,9 +108,11 @@ class ThunderbirdPulumiProject:
         return self.__aws_clients[key]
 
     def get_latest_amazon_linux_ami(self, region_name: str = None, name_alias: str = 'amzn2-ami-hvm-x86_64-gp2') -> str:
-        """Returns the AMI ID of the latest Amazon Linux 2 image for x86-archictecture HVM instances with GP2 storage
-        for the given region. This is accomplished by checking an `SSM parameter that AWS publishes
-        <https://aws.amazon.com/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/>`_
+        """Returns the AMI ID of the latest Amazon Linux 2 image for the given region. AWS provides many such AMIs for
+        various purposes. By default, this returns the AMI for the x86-architecture HVM image with GP2 storage. You can
+        specify a different image by providing the appropriate ``name_alias``. This is accomplished by checking an
+        `SSM parameter that AWS publishes
+        <https://aws.amazon.com/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/>`_.
 
         :param region_name: Name of the region to get the localized AMI ID for. Defaults to the project's region.
         :type region_name: str, optional

--- a/tb_pulumi/ec2.py
+++ b/tb_pulumi/ec2.py
@@ -10,7 +10,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-AMAZON_LINUX_AMI = 'ami-02ccbe126fe6afe82'  #: AMI for Amazon Linux
 
 
 class NetworkLoadBalancer(tb_pulumi.ThunderbirdComponentResource):
@@ -225,7 +224,8 @@ class SshableInstance(tb_pulumi.ThunderbirdComponentResource):
     :param subnet_id: The ID of the subnet to build the instance in.
     :type subnet_id: str
 
-    :param ami: ID of the AMI to build the instance with. Defaults to {AMAZON_LINUX_AMI}.
+    :param ami: ID of the AMI to build the instance with. Defaults to the latest image returned by
+        :py:meth:`tb_pulumi.ec2.get_latest_amazon_linux_ami`.
     :type ami: str, optional
 
     :param kms_key_id: ID of the KMS key for encrypting all database storage. Defaults to None.
@@ -260,7 +260,7 @@ class SshableInstance(tb_pulumi.ThunderbirdComponentResource):
         name: str,
         project: tb_pulumi.ThunderbirdPulumiProject,
         subnet_id: str,
-        ami: str = AMAZON_LINUX_AMI,
+        ami: str = None,
         kms_key_id: str = None,
         public_key: str = None,
         source_cidrs: list[str] = ['0.0.0.0/0'],
@@ -271,6 +271,9 @@ class SshableInstance(tb_pulumi.ThunderbirdComponentResource):
         **kwargs,
     ):
         super().__init__('tb:ec2:SshableInstance', name=name, project=project, opts=opts, **kwargs)
+
+        if not ami:
+            ami = project.get_latest_amazon_linux_ami()
 
         keypair = SshKeyPair(f'{name}-keypair', project, public_key=public_key)
 

--- a/tb_pulumi/ec2.py
+++ b/tb_pulumi/ec2.py
@@ -10,8 +10,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-
-
 class NetworkLoadBalancer(tb_pulumi.ThunderbirdComponentResource):
     """**Pulumi Type:** ``tb:ec2:NetworkLoadBalancer``
 


### PR DESCRIPTION
Amazon Linux 2 is an RPM-based Linux OS provided and supported by AWS. It's common practice to build instances using this image because it's the easiest way for AWS Support to be able to actually help. When we build EC2 instances, we currently use a hardcoded constant value.

The problem with this approach is that Amazon publishes new images frequently ([tracked here](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)), and we don't want to be responsible for updating this value in our codebase forever.

Amazon provides an SSM parameter that makes the latest AMI ID is discoverable. This PR removes the hardcoded ID in favor of a dynamic lookup that's aware of your project's region.