### PR TITLE
Specify region name when doing initial setup

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -65,7 +65,7 @@ class ThunderbirdPulumiProject:
         # AWS client setup
         self.__aws_clients = {}
         self.__aws_session = boto3.session.Session()
-        sts = self.get_aws_client('sts')
+        sts = self.get_aws_client(service='sts', region_name=self.__aws_session.region_name)
 
         #: Account number that the currently configured AWS user/role is a member of, in which Pulumi will act.
         self.aws_account_id: str = sts.get_caller_identity()['Account']


### PR DESCRIPTION
A previous code change created a problem for building new stacks: with no region specified at initialization time, this ends up calling another function that expects `self.__aws_region` to be set. However, that is set after this call is made, creating a bootstrapping/dependency error.

By specifying the region name in this way, we rely on the environment and AWSCLI's user configuration to determine the region at launch time.