### PR TITLE
Change default AL AMI

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -107,10 +107,12 @@ class ThunderbirdPulumiProject:
 
         return self.__aws_clients[key]
 
-    def get_latest_amazon_linux_ami(self, region_name: str = None, name_alias: str = 'amzn2-ami-hvm-x86_64-gp2') -> str:
-        """Returns the AMI ID of the latest Amazon Linux 2 image for the given region. AWS provides many such AMIs for
-        various purposes. By default, this returns the AMI for the x86-architecture HVM image with GP2 storage. You can
-        specify a different image by providing the appropriate ``name_alias``. This is accomplished by checking an
+    def get_latest_amazon_linux_ami(
+        self, region_name: str = None, name_alias: str = 'al2023-ami-minimal-kernel-6.1-x86_64'
+    ) -> str:
+        """Returns the AMI ID of the latest Amazon Linux 2023 image for the given region. AWS provides many such AMIs
+        for various purposes. By default, this returns the AMI for the x86-architecture HVM image with GP2 storage. You
+        can specify a different image by providing the appropriate ``name_alias``. This is accomplished by checking an
         `SSM parameter that AWS publishes
         <https://aws.amazon.com/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/>`_.
 
@@ -128,7 +130,7 @@ class ThunderbirdPulumiProject:
                     --query 'Parameters[*].Name' |
                     sed 's/\/aws\/service\/ami-amazon-linux-latest\///g'
 
-            Defaults to `amzn2-ami-hvm-x86_64-gp2`.
+            Defaults to `al2023-ami-minimal-kernel-6.1-x86_64`.
         :type name_alias: str, optional
         """
 


### PR DESCRIPTION
Turns out Amazon Linux 2 is tremendously out of date. I'm sure this is for security or stability purposes, but it also doesn't have access to a Python beyond 3.7. There are problems with pip being pointed to an old PyPi server that no longer passes TLS. While there are solutions to this, it feels like we're just starting off hamstrung by legacy problems that we have to solve before we even start working on our actual solution here.

So I'm changing this to use the more recent Amazon Linux 2023, which gets us Python 3.12 and Linux kernel 6.1.