### PR TITLE
Some minor improvements to the IAM module

### DIFF
--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -152,7 +152,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
                 'user': user,
                 'access_key': access_key,
                 'secret': secret,
-                'policy': policy,
+                'policy': secret_policy,
                 'policy_attachments': policy_attachments,
             }
         )

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -83,6 +83,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
 
         # The secret can only be created after the key has been created, so do it in a post-apply function
         secret_name = f'{self.project.project}/{self.project.stack}/iam.user.{user_name}.access_key'
+
         def __secret(access_key_id: str, secret_access_key: str):
             return tb_pulumi.secrets.SecretsManagerSecret(
                 name=f'{name}-keysecret',

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -82,6 +82,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
         )
 
         # The secret can only be created after the key has been created, so do it in a post-apply function
+        secret_name = f'{self.project.project}/{self.project.stack}/iam.user.{user_name}.access_key'
         def __secret(access_key_id: str, secret_access_key: str):
             return tb_pulumi.secrets.SecretsManagerSecret(
                 name=f'{name}-keysecret',
@@ -92,7 +93,6 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
                 opts=pulumi.ResourceOptions(parent=self, depends_on=[access_key]),
             )
 
-        secret_name = f'{self.project.project}/{self.project.stack}/iam.user.{user_name}.access_key'
         secret = pulumi.Output.all(access_key_id=access_key.id, secret_access_key=access_key.secret).apply(
             lambda outputs: __secret(
                 access_key_id=outputs['access_key_id'], secret_access_key=outputs['secret_access_key']
@@ -118,7 +118,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
             )
             return aws.iam.Policy(
                 f'{self.name}-keypolicy',
-                name=f'{user_name}_KeyAccess',
+                name=f'{user_name}-key-access',
                 policy=json.dumps(policy_doc),
                 description=f'Allows access to the secret which stores access key data for use {user_name}',
                 path='/',


### PR DESCRIPTION
- Per @MelissaAutumn 's [comment here](https://github.com/thunderbird/pulumi/pull/133#discussion_r2012867568), there's a small variable rename here to create clarity.
- Moved `secret_name` above the line where it's referenced. This didn't create a major problem because it's in a subfunction, but all the same, it hurt my brain to look at.
- Renamed the policy because `mailstrom-rjung-stalwart_KeyAccess` is an abomination.