### PR TITLE
Make Fargate service load balancers optional; fix exclude_from_project bug

### DIFF
--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -324,6 +324,7 @@ class FargateClusterWithLogging(tb_pulumi.ThunderbirdComponentResource):
         )
 
         # Fargate Service
+        service_depends_on = [item for item in [cluster, fargate_service_alb, task_definition_res] if item is not None]
         service = aws.ecs.Service(
             f'{name}-service',
             name=name,
@@ -339,7 +340,7 @@ class FargateClusterWithLogging(tb_pulumi.ThunderbirdComponentResource):
             },
             task_definition=task_definition_res,
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[cluster, fargate_service_alb, task_definition_res]),
+            opts=pulumi.ResourceOptions(parent=self, depends_on=service_depends_on),
         )
 
         self.finish(

--- a/tb_pulumi/rds.py
+++ b/tb_pulumi/rds.py
@@ -220,10 +220,7 @@ class RdsDatabaseGroup(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-        if 'exclude_from_project' in kwargs:
-            exclude_from_project = kwargs.pop('exclude_from_project', False)
-        else:
-            exclude_from_project = False
+        exclude_from_project = kwargs.pop('exclude_from_project', False)
 
         super().__init__(
             'tb:rds:RdsDatabaseGroup', name, project, exclude_from_project=exclude_from_project, opts=opts, tags=tags

--- a/tb_pulumi/rds.py
+++ b/tb_pulumi/rds.py
@@ -221,8 +221,9 @@ class RdsDatabaseGroup(tb_pulumi.ThunderbirdComponentResource):
         **kwargs,
     ):
         if 'exclude_from_project' in kwargs:
-            exclude_from_project = kwargs['exclude_from_project'] or False
-            del kwargs['exclude_from_project']
+            exclude_from_project = kwargs.pop('exclude_from_project', False)
+        else:
+            exclude_from_project = False
 
         super().__init__(
             'tb:rds:RdsDatabaseGroup', name, project, exclude_from_project=exclude_from_project, opts=opts, tags=tags

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -57,8 +57,9 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         **kwargs,
     ):
         if 'exclude_from_project' in kwargs:
-            exclude_from_project = kwargs['exclude_from_project'] or False
-            del kwargs['exclude_from_project']
+            exclude_from_project = kwargs.pop('exclude_from_project', False)
+        else:
+            exclude_from_project = False
 
         super().__init__(
             'tb:secrets:SecretsManagerSecret',

--- a/tb_pulumi/secrets.py
+++ b/tb_pulumi/secrets.py
@@ -56,10 +56,7 @@ class SecretsManagerSecret(tb_pulumi.ThunderbirdComponentResource):
         tags: dict = {},
         **kwargs,
     ):
-        if 'exclude_from_project' in kwargs:
-            exclude_from_project = kwargs.pop('exclude_from_project', False)
-        else:
-            exclude_from_project = False
+        exclude_from_project = kwargs.pop('exclude_from_project', False)
 
         super().__init__(
             'tb:secrets:SecretsManagerSecret',


### PR DESCRIPTION
You can now set `build_load_balancer: False` in your YAML config to prevent the buildout of an ALB against a `FargateClusterWithLogging`.

Also, there's a bug where if `exclude_from_project` is not implemented well, we throw this error:

```
UnboundLocalError: cannot access local variable 'exclude_from_project' where it is not associated with a value
```

This should resolve issue #151.