### PR TITLE
Add patterns to build S3 websites and generic CloudFront distributions

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -45,7 +45,8 @@ class ThunderbirdPulumiProject:
         #: Pulumi Resource objects managed by this project
         self.resources: dict = {}
 
-        self.common_tags: dict = {  #: Tags to apply to all taggable resources
+        #: Tags to apply to all taggable resources
+        self.common_tags: dict = {
             'environment': self.stack,
             'project': self.project,
             'pulumi_project': self.project,

--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -67,7 +67,6 @@ class CloudFrontDistribution(tb_pulumi.ThunderbirdComponentResource):
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
-
         exclude_from_project = kwargs.pop('exclude_from_project', False)
         super().__init__(
             'tb:cloudfront:CloudFrontS3Service',

--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -32,19 +32,42 @@ class CloudFrontDistribution(tb_pulumi.ThunderbirdComponentResource):
         - *logging_bucket_ownership* - `aws.s3.BucketOwnershipControls
           <https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketownershipcontrols/>`_ which allow CloudFront
           to upload logs into the logging bucket.
+
+    :param name: A string identifying this set of resources.
+    :type name: str
+
+    :param project: The ThunderbirdPulumiProject to add these resources to.
+    :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param logging_bucket_name: Name of the S3 bucket which holds access logs for the distribution.
+    :type logging_bucket_name: str
+
+    :param distribution: A mapping of `CloudFront Distribution Resource inputs
+        <https://www.pulumi.com/registry/packages/aws/api-docs/cloudfront/distribution/#inputs>`_ . Defaults to {}.
+    :type distribution: dict, optional
+
+    :param forcibly_destroy_bucket: When True, pulumi actions which destroy the logging bucket will cause the bucket to
+        be fully emptied beforehand, **permanently destroying all data in the bucket**. Defaults to False.
+    :type forcibly_destroy_bucket: bool, optional
+
+    :param opts: Additional pulumi.ResourceOptions to apply to these resources. Defaults to None.
+    :type opts: pulumi.ResourceOptions, optional
+
+    :param kwargs: Any other keyword arguments which will be passed as inputs to the ``ThunderbirdComponentResource``
+        resource.
     """
 
     def __init__(
         self,
         name: str,
         project: tb_pulumi.ThunderbirdPulumiProject,
-        certificate_arn: str,
         logging_bucket_name: str,
         distribution: dict = {},
         forcibly_destroy_bucket: bool = False,
         opts: pulumi.ResourceOptions = None,
         **kwargs,
     ):
+
         exclude_from_project = kwargs.pop('exclude_from_project', False)
         super().__init__(
             'tb:cloudfront:CloudFrontS3Service',
@@ -154,7 +177,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
     :param project: The ThunderbirdPulumiProject to add these resources to.
     :type project: tb_pulumi.ThunderbirdPulumiProject
 
-    :param certificate_arn: The ARN of the ACM certificate used for TLS in this distribution. `AWS CloudFront
+    :param certificate_arn: The ARN of the ACM certificate used for TLS in this distribution. `AWS CloudFront SSL
         <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-aws-region>`_
         requires that this certificate exist in the ``us-east-1`` region.
     :type certificate_arn: str

--- a/tb_pulumi/constants.py
+++ b/tb_pulumi/constants.py
@@ -6,6 +6,10 @@ ASSUME_ROLE_POLICY = {
     'Statement': [{'Sid': '', 'Effect': 'Allow', 'Principal': {'Service': None}, 'Action': 'sts:AssumeRole'}],
 }
 
+CLOUDFRONT_CACHE_POLICY_ID_OPTIMIZED = '658327ea-f89d-4fab-a63d-7e88639e58f6'  # "Managed-CachingOptimized" policy
+CLOUDFRONT_CACHE_POLICY_ID_DISABLED = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad'  # "Managed-CachingDisabled" policy
+CLOUDFRONT_ORIGIN_REQUEST_POLICY_ID_ALLVIEWER = '216adef6-5c7f-47e4-b989-5492eafa07d3'  # "Managed-AllViewer" policy
+
 #: Most common settings for Cloudwatch metric alarms
 CLOUDWATCH_METRIC_ALARM_DEFAULTS = {
     'enabled': True,

--- a/tb_pulumi/s3.py
+++ b/tb_pulumi/s3.py
@@ -149,6 +149,14 @@ class S3BucketWebsite(tb_pulumi.ThunderbirdComponentResource):
     Produces the following ``resources``:
 
         - **bucket** - A :py:class:`tb_pulumi.s3.S3Bucket` to host the static files.
+        - **bucket_acl** - An `aws.s3.BucketAclV2
+          <https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketaclv2/>`_ describing public read access.
+        - **bucket_oc** - An `aws.s3.BucketOwnershipControls
+          <https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketownershipcontrols/>`_ describing how object
+          ownership works.
+        - **bucket_pab** - An `aws.s3.BucketPublicAccessBlock
+          <https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketpublicaccessblock/>`_ which disables the
+          blocks on public access.
         - **objects** - A dict where the keys are files discovered in the ``content_dir`` local directory and the values
           are `aws.s3.BucketObjectv2 <https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketobjectv2/>`_ s.
         - **policy** - An `aws.s3.BucketPolicy


### PR DESCRIPTION
## Description of the Change

The wider-scope perspective here is that we want to present specific Thunderbird autoconfig files for our Thundermail services, and that format differs from that of the autoconfig files that Stalwart serves. This means hosting the file ourselves and presenting it to the world. But the existing S3 and CloudFront patterns we have are insufficient for a few reasons.

## Benefits

Serving an autoconfig through an S3 website as opposed to just an S3 bucket as a CloudFront origin gives us the ability to present a file as the index document. If we just use the bucket-origin model, then calls to `https://autoconfig.thedomain.tld/` would return 404s. It also lets us present a custom error page and set up redirects to present this data more consistently.

See additional notes in-line.