### PR TITLE
Add monitoring for network load balancers

### DIFF
--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -171,6 +171,7 @@ class LoadBalancerAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         resource.load_balancer_type.apply(lambda lb_type: self.__build_alarm_group(lb_type))
 
     def __build_alarm_group(self, lb_type: str):
+        # ALBs have some useful metrics for alarms, but NLBs do not. Therefore, we don't do anything for NLBs.
         if lb_type == 'application':
             self.alarm_group = AlbAlarmGroup(
                 name=self.name,
@@ -622,7 +623,11 @@ class Ec2InstanceAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
 
     A set of alarms for EC2 instances. Contains the following configurable alarms:
 
+        - ``cpu_credit_balance``: Alarms if your instance is low on CPU credits.
         - ``cpu_utilization``: Alarms on the percentage of CPU time the instance is using.
+        - ``ebs_status_failed``: Alarms if the EBS volume status check fails.
+        - ``instance_status_failed``: Alarms if the EC2 instance status check fails.
+        - ``system_status_failed``: Alarms if the system status check fails.
 
     Further detail on these metrics and more can be found on `Amazon's documentation
     <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html>_`.

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -60,6 +60,7 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         type_map = {
             aws.ec2.Instance: Ec2InstanceAlarmGroup,
             aws.lb.load_balancer.LoadBalancer: LoadBalancerAlarmGroup,
+            aws.alb.target_group.TargetGroup: LbTargetGroupAlarmGroup,
             aws.lb.target_group.TargetGroup: LbTargetGroupAlarmGroup,
             aws.cloudfront.Distribution: CloudFrontDistributionAlarmGroup,
             aws.cloudfront.Function: CloudFrontFunctionAlarmGroup,

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -61,6 +61,7 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
             aws.ec2.Instance: Ec2InstanceAlarmGroup,
             aws.lb.load_balancer.LoadBalancer: LoadBalancerAlarmGroup,
             aws.alb.target_group.TargetGroup: AlbTargetGroupAlarmGroup,
+            aws.lb.target_group.TargetGroup: AlbTargetGroupAlarmGroup,
             aws.cloudfront.Distribution: CloudFrontDistributionAlarmGroup,
             aws.cloudfront.Function: CloudFrontFunctionAlarmGroup,
             aws.ecs.Service: EcsServiceAlarmGroup,

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -60,8 +60,7 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
         type_map = {
             aws.ec2.Instance: Ec2InstanceAlarmGroup,
             aws.lb.load_balancer.LoadBalancer: LoadBalancerAlarmGroup,
-            aws.alb.target_group.TargetGroup: AlbTargetGroupAlarmGroup,
-            aws.lb.target_group.TargetGroup: AlbTargetGroupAlarmGroup,
+            aws.lb.target_group.TargetGroup: LbTargetGroupAlarmGroup,
             aws.cloudfront.Distribution: CloudFrontDistributionAlarmGroup,
             aws.cloudfront.Function: CloudFrontFunctionAlarmGroup,
             aws.ecs.Service: EcsServiceAlarmGroup,
@@ -331,10 +330,10 @@ class AlbAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         )
 
 
-class AlbTargetGroupAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
-    """**Pulumi Type:** ``tb:cloudwatch:CloudFrontDistributionAlarmGroup``
+class LbTargetGroupAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
+    """**Pulumi Type:** ``tb:cloudwatch:LbTargetGroupAlarmGroup``
 
-    A set of alarms for ALB target groups. Contains the following configurable alarms:
+    A set of alarms for EC2 load balancer target groups. Contains the following configurable alarms:
 
         - ``unhealthy_hosts``: Alarms on the number of unhealthy hosts in a target group. Defaults to alarm when the
           average of unhealthy hosts is over 1 in 1 minute.
@@ -342,7 +341,7 @@ class AlbTargetGroupAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
     Further detail on these metrics and others can be found within `Amazon's Target Group metric documentation
     <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html#target-metric-table>`_.
 
-    :param name: The name of the the ``AlbTargetGroupAlarmGroup`` resource.
+    :param name: The name of the the ``LbTargetGroupAlarmGroup`` resource.
     :type name: str
 
     :param project: The ``ThunderbirdPulumiProject`` being monitored.
@@ -371,7 +370,7 @@ class AlbTargetGroupAlarmGroup(tb_pulumi.monitoring.AlarmGroup):
         **kwargs,
     ):
         super().__init__(
-            pulumi_type='tb:cloudwatch:AlbTargetGroupAlarmGroup',
+            pulumi_type='tb:cloudwatch:LbTargetGroupAlarmGroup',
             name=name,
             monitoring_group=monitoring_group,
             project=project,


### PR DESCRIPTION
As it turns out, NLBs produce some useful debugging metrics, but nothing in particular to report on unless we start seeing real problems that are indicated by traffic volume. However, the target groups attached to those NLBs do produce useful alarms. This PR makes it so that target groups attached to NLBs get the same alarms built as those attached to ALBs. Because that alarm group is being used for both types of target groups, I have also refactored the class name to not be incorrect.