### PR TITLE
Exit on error; let Pulumi manage its own venv

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 ### Usage
 #
 #     Run this script, supplying the arguments outlined below in this specific order:
@@ -67,7 +69,6 @@ pulumi new aws-python --name $PROJECT_NAME --stack $STACK_NAME
 
 echo "Setting up tb_pulumi"
 echo "tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@$CODE_VERSION" > requirements.txt
-pip install -r requirements.txt
 
 cp $REPO_DIR/__main__.py.example ./__main__.py
 cp $REPO_DIR/config.stack.yaml.example ./config.$STACK_NAME.yaml


### PR DESCRIPTION
Adding `set -e` here so the script will crash out instead of continuing after an error has occurred.

Also removing a pip install command because Pulumi manages its own virtual environment. All we have to do is place the `requirements.txt` file and it will work.