### PR TITLE
Bump required Python version for automation

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Python 3.12
+      - name: Install Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build docs
         shell: bash


### PR DESCRIPTION
Yesterday, I [bumped the required version of Python](https://github.com/thunderbird/pulumi/pull/180) to 3.13 because of a change made to Python's `pathlib.Path.glob` function. This automation has [just failed](https://github.com/thunderbird/pulumi/actions/runs/16354330051/job/46208778041) because of the wrong Python version being installed.

This PR fixes the automation to use the correct version of Python.