### PR TITLE
Implement stack-level IAM access policies

### DIFF
--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -79,12 +79,9 @@ class CloudWatchMonitoringGroup(tb_pulumi.monitoring.MonitoringGroup):
             config=config,
         )
 
-    def monitor(self, outputs):
+    def monitor(self):
         """This function gets called only after all outputs in the project have been resolved into values. It constructs
         all monitors for the resources in this project.
-
-        :param outputs: A list of resolved outputs discovered in the project.
-        :type outputs: list
         """
 
         sns_topic = aws.sns.Topic(

--- a/tb_pulumi/constants.py
+++ b/tb_pulumi/constants.py
@@ -26,6 +26,22 @@ DEFAULT_PROTECTED_STACKS = ['prod']  #: Which Pulumi stacks should get resource 
 #: IAM policies often extend this template.
 IAM_POLICY_DOCUMENT = {'Version': '2012-10-17', 'Statement': [{'Sid': 'DefaultSid', 'Effect': 'Allow'}]}
 
+#: IAM ARNs have a "path" portion, and these are the valid values
+IAM_RESOURCE_PATHS = [
+    'access-report',
+    'federated-user',
+    'group',
+    'instance-profile',
+    'mfa',
+    'oidc-provider',
+    'policy',
+    'report',
+    'role',
+    'saml-provider',
+    'server-certificate',
+    'sms-mfa',
+    'user',
+]
 #: Map of common services to their typical ports
 SERVICE_PORTS = {
     'mariadb': 3306,

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -3,10 +3,223 @@
 import json
 import pulumi
 import pulumi_aws as aws
-import tb_pulumi
+import re
+import string
 import tb_pulumi.secrets
 
-from tb_pulumi.constants import IAM_POLICY_DOCUMENT
+from tb_pulumi.constants import IAM_POLICY_DOCUMENT, IAM_RESOURCE_PATHS
+
+
+class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
+    """Creates two IAM policies granting read-only and full admin access to all resources in this project."""
+
+    def __init__(
+        self,
+        name: str,
+        project: tb_pulumi.ThunderbirdPulumiProject,
+        opts: pulumi.ResourceOptions = None,
+        tags: dict = {},
+    ):
+        super().__init__(pulumi_type='tb:iam.StackAccessPolicies', name=name, project=project, opts=opts, tags=tags)
+
+    def ready(self, outputs: list[pulumi.Resource]):
+        """This function is called by the :py:class:`tb_pulumi.ProjectResourceGroup` after all outputs in the project
+        have been resolved into values. Here, we go through every resource to get an exhaustive list of resource ARNs.
+        Those are used to determine a list of AWS services in use by the project. An IAM policy is produced that has
+        read-only access to those resources.
+        """
+
+        arns = [resource.arn for resource in self.all_resources if getattr(resource, 'arn', False)]
+        pulumi.Output.all(*arns).apply(lambda arns: self.build_policies(arns))
+
+    def build_policies(self, arns: list[str]):
+        """Defines the IAM policies which govern access to the given list of resources.
+
+        :param arns: List of resource ARNs to build policies around. This is automatically provided by the
+            :py:meth:`ready` function when a stack's state has been achieved in a Pulumi run.
+        :type arns: list[str]
+        """
+
+        # Start by getting a list of services in use by this project, extracted from the ARNs
+        services = sorted(set([arn.split(':')[2] for arn in arns]))
+
+        ####  WHY IS THIS SO COMPLICATED?  ####
+        #
+        #   There are a variety of limitations and gotchas involved with IAM and how it interacts with other AWS
+        #   platforms. We must account for all of these complexities:
+        #
+        #   - A policy document can be no longer than 6,144 characters. This precludes the simplest of logic where all
+        #     relevant actions for all resources are listed. That scales far too quickly along this metric.
+        #   - A user may have no more than 10 attached policies (though this can be increased as high as 20 through a
+        #     quota increase).
+        #   - A user group may also have only 10 attached policies, and that cannot be extended. AWS's own advice here
+        #     is to create user groups -- each with as many as 10 attached policies -- and then place users into those
+        #     groups. Since users can additionally have up to 20 directly attached polices after the quota increase,
+        #     this leads to a maximum of 120 policies. Ref: https://repost.aws/knowledge-center/iam-increase-policy-size
+        #     https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entities
+        #   - Most resources use the user-friendly names we provide as part of the ARN, meaning we can use patterns to
+        #     create appropriate permission boundaries. But some legacy services (and others, like CloudFront) use
+        #     randomly generated IDs instead. These can't be predicted or controlled, and we can't create safe
+        #     boundaries through patterns.
+        #   - Some services are global and therefore the ARNs do not have regions. Sometimes it's okay to use a "*" and
+        #     sometimes it's not. That depends on a lot of apparent finnickiness on the AWS side of things, how "legacy"
+        #     the service is, etc. Sometimes an ARN doesn't have an account ID. All of this is really sticky and has
+        #     been worked out through trial.
+        #
+        #   All of these very special behaviors and the methods we use to deal with them are documented below in the
+        #   hopes that this code remains maintainable.
+
+        admin_policies = {}  # Policies granting administrative access to services
+        readonly_policies = {}  # Policies granting read-only access to services
+        referenced_arns = []  # List of ARNs which have been accounted for in these policies
+        for service in services:
+            # Many ARNs can be collapsed into a single pattern, provided our tool has been used as designed and AWS is
+            # uniform in its ARNs, which allows us to condense our policies quite a bit. But the Python regular
+            # expression we use to identify and track those ARNs in this function differs from the pattern that means
+            # the same thing in an IAM policy. Here we create a Python regex (common_arn_regex) and an IAM resource
+            # pattern (common_arn_policy_pattern) that are equivalent so we can use the right format in the right place.
+            if service == 'secretsmanager':
+                # Secrets Manager tends to use slashes ("/") instead of dashes ("-").
+                common_arn_regex = (
+                    f'arn:aws:{service}:.*:{self.project.aws_account_id}:'
+                    f'.*{self.project.name_prefix.replace("-", "/")}.*'
+                )
+            else:
+                common_arn_regex = (
+                    f'arn:aws:{service}:({self.project.aws_region})*:{self.project.aws_account_id}:'
+                    f'.*{self.project.name_prefix}.*'
+                )
+
+            if service == 'iam':
+                # Hardcode this "<path>" placeholder here; we have to expand this out to multiple resources later
+                common_arn_policy_pattern = (
+                    f'arn:aws:{service}::{self.project.aws_account_id}:<path>/*{self.project.name_prefix}*'
+                )
+            elif service == 's3':
+                # S3 ARNs have no account ID in them
+                common_arn_policy_pattern = f'arn:aws:{service}:::*{self.project.name_prefix}*'
+            elif service == 'secretsmanager':
+                # Secrets Manager tends to use slashes ("/") instead of dashes ("-").
+                common_arn_policy_pattern = (
+                    f'arn:aws:{service}:*:{self.project.aws_account_id}:*{self.project.name_prefix.replace("-", "/")}*'
+                )
+            else:
+                common_arn_policy_pattern = (
+                    f'arn:aws:{service}:*:{self.project.aws_account_id}:*{self.project.name_prefix}*'
+                )
+
+            # ARNs for many resources (security groups, VPCs, etc.) do not use names and must be listed out by ID. Here,
+            # service_arns is all ARNs for a given service, while uncommon_arns are a subset of those ARNs which are not
+            # matched by the policy pattern.
+            service_arns = [arn for arn in arns if arn.split(':')[2] == service]
+            uncommon_arns = [arn for arn in service_arns if not re.match(common_arn_regex, arn)]
+            
+            # "Describe" and "List" actions are typically safe for read-only access.
+            readonly_actions = [
+                f'{service}:Describe*',
+                f'{service}:List*',
+            ]
+
+            # "Get" actions are also typically safe, but there is at least this exception: The only "Get" action that's
+            # useful to a read-only user of Secrets Manager is "GetSecretValue". But these values often contain secrets
+            # that allow administrative access to other systems, such as databases. Allowing a read-only user to access
+            # these secrets potentially constitutes a privilege escalation, so we intentionally exclude this action from
+            # Secrets Manager policies.
+            if service != 'secretsmanager':
+                readonly_actions.append(f'{service}:Get*')
+
+            # To save on policy character length, only list explicitly those resources which are not matched by our
+            # common pattern. First, we include that common pattern as the first resource.
+            if service == 'iam':
+                # ARNs for IAM resources have a "path" component after the account ID and before the resource name. You
+                # cannot substitute this with a "*" in a policy; doing so yields a 400 from the API. We can wildcard the
+                # rest of the ARN, but we must list a resource for every IAM resource path in the policy.
+                resources = [common_arn_policy_pattern.replace('<path>', path) for path in IAM_RESOURCE_PATHS]
+            else:
+                resources = [common_arn_policy_pattern]
+            # Now list the uncommon ones.
+            resources.extend(uncommon_arns)
+
+            # Inject our resources and actions into a readonly policy
+            policy_doc = {
+                'Version': '2012-10-17',
+                'Statement': [{'Effect': 'Allow', 'Resource': resources, 'Action': readonly_actions}],
+            }
+
+            # Statement IDs in IAM policies must be alphanumeric. Here we normalize our inputs against that constraint.
+            valid_chars = string.ascii_letters + '0123456789'
+            service_sid_prefix = f'{self.project.project.title()}{self.project.stack.title()}{service.title()}'
+            service_sid_prefix = ''.join([ char for char in service_sid_prefix if char in valid_chars ])
+
+            # Form the read-only policy
+            policy_doc['Statement'][0]['Sid'] = f'{service_sid_prefix}ReadOnly'
+            policy_name = f'{self.name}-policy-{service}-readonly'
+            readonly_policies[service] = aws.iam.Policy(
+                policy_name,
+                name=policy_name,
+                description=f'Allow read-only access to {service} resources in the {self.project.name_prefix} stack',
+                path='/',
+                policy=json.dumps(policy_doc),
+                opts=pulumi.ResourceOptions(parent=self),
+                tags=self.tags,
+            )
+
+            # Also build a more permissive admin policy by updating the read-only policy doc's actions
+            policy_doc['Statement'][0]['Sid'] = f'{service_sid_prefix}Admin'
+            policy_doc['Statement'][0]['Action'] = ['*']
+            policy_name = f'{self.name}-policy-{service}-admin'
+            admin_policies[service] = aws.iam.Policy(
+                policy_name,
+                name=policy_name,
+                description=f'Allow admin access to {service} resources in the {self.project.name_prefix} stack',
+                path='/',
+                policy=json.dumps(policy_doc),
+                opts=pulumi.ResourceOptions(parent=self),
+                tags=self.tags,
+            )
+
+        # Build a user group for admins, attaching the admin policies generated above.
+        admin_group = aws.iam.Group(
+            f'{self.name}-usergroup-admin',
+            name=f'{self.name}-admin',
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+        admin_policy_attachments = {
+           service: aws.iam.GroupPolicyAttachment(
+                f'{self.name}-gpa-admin-{service}',
+                group=admin_group.name,
+                policy_arn=policy.arn,
+                opts=pulumi.ResourceOptions(parent=self),
+            )
+            for service, policy in admin_policies.items()
+        }
+
+        # Build a group for read-only users, attaching the less permissive policies.
+        readonly_group = aws.iam.Group(
+            f'{self.name}-usergroup-readonly',
+            name=f'{self.name}-readonly',
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+        readonly_policy_attachments = {
+            name: aws.iam.GroupPolicyAttachment(
+                f'{self.name}-gpa-readonly-{idx}',
+                group=readonly_group.name,
+                policy_arn=policy.arn,
+                opts=pulumi.ResourceOptions(parent=self),
+            )
+            for idx, (name, policy) in enumerate(readonly_policies.items())
+        }
+        
+        self.finish(
+            resources={
+                'admin_group': admin_group,
+                'admin_policies': admin_policies,
+                'admin_policy_attachments': admin_policy_attachments,
+                'readonly_group': readonly_group,
+                'readonly_policies': readonly_policies,
+                'readonly_policy_attachments': readonly_policy_attachments,
+            }
+        )
 
 
 class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -71,7 +71,6 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
 
         admin_policies = {}  # Policies granting administrative access to services
         readonly_policies = {}  # Policies granting read-only access to services
-        referenced_arns = []  # List of ARNs which have been accounted for in these policies
         for service in services:
             # Many ARNs can be collapsed into a single pattern, provided our tool has been used as designed and AWS is
             # uniform in its ARNs, which allows us to condense our policies quite a bit. But the Python regular

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -113,7 +113,7 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
             # matched by the policy pattern.
             service_arns = [arn for arn in arns if arn.split(':')[2] == service]
             uncommon_arns = [arn for arn in service_arns if not re.match(common_arn_regex, arn)]
-            
+
             # "Describe" and "List" actions are typically safe for read-only access.
             readonly_actions = [
                 f'{service}:Describe*',
@@ -149,7 +149,7 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
             # Statement IDs in IAM policies must be alphanumeric. Here we normalize our inputs against that constraint.
             valid_chars = string.ascii_letters + '0123456789'
             service_sid_prefix = f'{self.project.project.title()}{self.project.stack.title()}{service.title()}'
-            service_sid_prefix = ''.join([ char for char in service_sid_prefix if char in valid_chars ])
+            service_sid_prefix = ''.join([char for char in service_sid_prefix if char in valid_chars])
 
             # Form the read-only policy
             policy_doc['Statement'][0]['Sid'] = f'{service_sid_prefix}ReadOnly'
@@ -185,7 +185,7 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
             opts=pulumi.ResourceOptions(parent=self),
         )
         admin_policy_attachments = {
-           service: aws.iam.GroupPolicyAttachment(
+            service: aws.iam.GroupPolicyAttachment(
                 f'{self.name}-gpa-admin-{service}',
                 group=admin_group.name,
                 policy_arn=policy.arn,
@@ -209,7 +209,7 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
             )
             for idx, (name, policy) in enumerate(readonly_policies.items())
         }
-        
+
         self.finish(
             resources={
                 'admin_group': admin_group,

--- a/tb_pulumi/s3.py
+++ b/tb_pulumi/s3.py
@@ -238,13 +238,15 @@ class S3BucketWebsite(tb_pulumi.ThunderbirdComponentResource):
         )
 
         policy_json = tb_pulumi.constants.IAM_POLICY_DOCUMENT.copy()
-        policy_json['Statement'][0] = {
-            'Sid': 'PublicReadGetObject',
-            'Effect': 'Allow',
-            'Principal': '*',
-            'Action': ['s3:GetObject'],
-            'Resource': [f'arn:aws:s3:::{bucket_name}/*'],
-        }
+        policy_json['Statement'] = [
+            {
+                'Sid': 'PublicReadGetObject',
+                'Effect': 'Allow',
+                'Principal': '*',
+                'Action': ['s3:GetObject'],
+                'Resource': [f'arn:aws:s3:::{bucket_name}/*'],
+            }
+        ]
         policy_json = json.dumps(policy_json)
         policy = aws.s3.BucketPolicy(
             f'{name}-policy',


### PR DESCRIPTION
## Description of the Change

Per Issue #147, we would like to have a way of granting a person access to an application environment's resources without those permissions spilling over into other environments. We want to be able to grant admin access to an env when it's necessary (like giving a developer access to a personal testing environment or granting a CI user the ability to manipulate its own environment), and read-only access at other times (f/ex, giving a security auditor the ability to inspect infrastructure without manipulating it). To accomplish this, we make two main changes here.

First, I refactored the code that gives us access to a stack's resources in its fully applied state so that it no longer lives in the monitoring code, but instead now has a home at the base of the tb_pulumi module. This is a `ProjectResourceGroup`. You can now easily create these "post-apply" features by simply extending this class and implementing its `ready` function. The `monitoring.MonitoringGroup` class is now such an extension, but is otherwise unchanged here.

Second, I added a new `ProjectResourceGroup` called `StackAccessPolicies`. This creates IAM policies for each service that you have resources in. One of these offers read-only access to only the resources in this singular stack (read: "environment"), the other full admin access. The commentary in the code contains a lot of details I won't repeat here as to why this is the best model for us, but suffice it to say that there are some complexities to work around here.

## Benefits

We can now stick users in these user groups (or even attach these policies directly) to better control access within an environment.

## Applicable Issues

#147 
