### PR TITLE
Ensure validation steps run for PRs coming from forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - '**'
       - '!main'
+  pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 permissions:
   contents: read


### PR DESCRIPTION
This adds various PR-related events as triggers for code validation. This must be here if we want to run the same validations on PRs coming from forked repos.