### PR TITLE
Allow users to add an `iam.UserWithAccessKey` to user groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<45.0
 pulumi>=3.130.0,<4.0.0
-pulumi-aws==6.65.0
+# pulumi-aws==6.65.0
+pulumi_aws==7.6.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 boto3>=1.34,<2.0
 cryptography>=43.0.0,<45.0
 pulumi>=3.130.0,<4.0.0
-# pulumi-aws==6.65.0
-pulumi_aws==7.6.0
+pulumi-aws==6.65.0
 pulumi-random>=4.16,<5.0
 # pyyaml is also a requirement, but is installed for us by pulumi

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -345,7 +345,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
                 f'{self.name}-keypolicy',
                 name=f'{user_name}-key-access',
                 policy=json.dumps(policy_doc),
-                description=f'Allows access to the secret which stores access key data for use {user_name}',
+                description=f'Allows access to the secret which stores access key data for user {user_name}',
                 path='/',
                 tags=self.tags,
                 opts=pulumi.ResourceOptions(parent=self, depends_on=[secret]),
@@ -361,7 +361,7 @@ class UserWithAccessKey(tb_pulumi.ThunderbirdComponentResource):
         )
 
         # Add the user to all the given groups
-        group_membership = aws.iam.GroupMembership(
+        group_membership = aws.iam.UserGroupMembership(
             f'{self.name}-gpmbr',
             groups=[group.name for group in groups],
             user=user.name,


### PR DESCRIPTION
## Description of the Change

This adds an optional `groups` parameter to `iam.UserWithAccessKey`, which is a list of `aws.iam.Group`s to create a group membership in.

## Benefits

Don't need to build an `aws.iam.UserGroupMembership` outside of the user class.

## Applicable Issues

#209 