### PR TITLE
Allow running more code downstream from project resource groups

### DIFF
--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -431,7 +431,8 @@ class ProjectResourceGroup(ThunderbirdComponentResource):
         raise NotImplementedError()
 
     def finish(self, resources: dict[str, Flattenable] = {}):
-        """Calls the superclass's ``finish`` function to register resources, then
+        """Calls the superclass's ``finish`` function to register resources, then calls the callback function if one was
+        set, passing in the resources.
 
         :param outputs: Dict of outputs to register with Pulumi's ``register_outputs`` function. This parameter is
             deprecated and will be removed in a future version. Defaults to {}.
@@ -445,6 +446,6 @@ class ProjectResourceGroup(ThunderbirdComponentResource):
 
         def __callback(resources):
             if self.on_apply is not None:
-                self.on_apply(resources)
+                self.on_apply(resources=resources)
 
-        pulumi.Output.apply(**resources).apply(lambda resources: __callback(resources=resources))
+        pulumi.Output.all(**resources).apply(lambda resources: __callback(resources=resources))

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -434,10 +434,6 @@ class ProjectResourceGroup(ThunderbirdComponentResource):
         """Calls the superclass's ``finish`` function to register resources, then calls the callback function if one was
         set, passing in the resources.
 
-        :param outputs: Dict of outputs to register with Pulumi's ``register_outputs`` function. This parameter is
-            deprecated and will be removed in a future version. Defaults to {}.
-        :type outputs: dict[str, Any], optional
-
         :param resources: Dict of Pulumi resources this component reosurce contains. Defaults to {}.
         :type resources: dict[str, Flattenable], optional
         """

--- a/tb_pulumi/__init__.py
+++ b/tb_pulumi/__init__.py
@@ -443,5 +443,8 @@ class ProjectResourceGroup(ThunderbirdComponentResource):
 
         super().finish(resources=resources)
 
-        if self.on_apply is not None:
-            self.on_apply(resources)
+        def __callback(resources):
+            if self.on_apply is not None:
+                self.on_apply(resources)
+
+        pulumi.Output.apply(**resources).apply(lambda resources: __callback(resources=resources))

--- a/tb_pulumi/iam.py
+++ b/tb_pulumi/iam.py
@@ -19,8 +19,11 @@ class StackAccessPolicies(tb_pulumi.ProjectResourceGroup):
         project: tb_pulumi.ThunderbirdPulumiProject,
         opts: pulumi.ResourceOptions = None,
         tags: dict = {},
+        **kwargs,
     ):
-        super().__init__(pulumi_type='tb:iam.StackAccessPolicies', name=name, project=project, opts=opts, tags=tags)
+        super().__init__(
+            pulumi_type='tb:iam.StackAccessPolicies', name=name, project=project, opts=opts, tags=tags, **kwargs
+        )
 
     def ready(self, outputs: list[pulumi.Resource]):
         """This function is called by the :py:class:`tb_pulumi.ProjectResourceGroup` after all outputs in the project


### PR DESCRIPTION
## Description of the Change

We can currently build out these `ProjectResourceGroup`s that act on all resources in a project. But what if I need to build something else that depends on a `ProjectResourceGroup`? How do I run code from this post-post-applied state?

The answer: a pretty simple callback, actually, that can be optionally invoked when a `ProjectResourceGroup` calls its `finish` function. 

## Benefits

Can do things like assign IAM users to groups built by a `StackAccessPolicies` resource.