### PR TITLE
Make CloudFront logging optional

### DIFF
--- a/tb_pulumi/cloudfront.py
+++ b/tb_pulumi/cloudfront.py
@@ -358,6 +358,8 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
         }
         if 'default_cache_behavior' in distribution:
             default_cache_behavior.update(distribution.pop('default_cache_behavior'))
+
+        depends_on = [dep for dep in [logging_bucket, oac] if dep is not None]
         cloudfront_distribution = aws.cloudfront.Distribution(
             f'{name}-cfdistro',
             default_cache_behavior=default_cache_behavior,
@@ -373,7 +375,7 @@ class CloudFrontS3Service(tb_pulumi.ThunderbirdComponentResource):
             tags={**self.tags, 'Name': f'{name}-cfdistro'},
             opts=pulumi.ResourceOptions(
                 parent=self,
-                depends_on=[logging_bucket, oac],
+                depends_on=depends_on,
             ),
             **distribution,
         )


### PR DESCRIPTION
## Description of the Change

There is something broken about this logging configuration, and we need to be able to opt out of it to bring an environment online. We will file a ticket about this soon and start working toward a proper resolution where logging works, but for now we have a more urgent need.

This does not change the default behavior used by other projects.

## Benefits

Gives us the ability to get an environment online despite a bad configuration.
