### PR TITLE
Set propagate_tags to inherit from service definition

### DIFF
--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -345,6 +345,7 @@ class FargateClusterWithLogging(tb_pulumi.ThunderbirdComponentResource):
                 'security_groups': container_security_groups,
             },
             task_definition=task_definition_res,
+            propagate_tags='SERVICE',
             tags=self.tags,
             opts=pulumi.ResourceOptions(**service_opts),
         )


### PR DESCRIPTION
<!--
* Filling out the template is required.
* Please run through the PR checklist found in our documentation before submitting a pull request
  - https://thunderbird.github.io/pulumi/development.html#pull-request-requirements
-->

## Description of the Change
Tasks do not automatically inherit tags from the service or task definition. I've set propagate_tags = 'SERVICE'  to enable this. 'TASK' is also a valid parent, but I went with services as is.

Tested on send stage:
`   [urn=urn:pulumi:stage::send-suite::pulumi:pulumi:Stack::send-suite-stage]
        ~ aws:ecs/service:Service: (update)
            [id=arn:aws:ecs:eu-central-1:768512802988:service/send-suite-stage-fargate/send-suite-stage-fargate]
            [urn=urn:pulumi:stage::send-suite::tb:fargate:FargateClusterWithLogging$aws:ecs/service:Service::send-suite-stage-fargate-service]
            [provider=urn:pulumi:stage::send-suite::pulumi:providers:aws::default_6_65_0::8dc03e22-9372-41c4-8e03-577d58e90694]
          ~ propagateTags : "NONE" => "SERVICE"
          ~ taskDefinition: "send-suite-stage-fargate:27" => "send-suite-stage-fargate"`

Here is a task that inherited it's values from the service.
<img width="1254" height="365" alt="Screenshot 2025-11-17 at 10 43 49 AM" src="https://github.com/user-attachments/assets/cc5ceaf5-1c17-429c-b47a-7b72507b19aa" />


## Benefits

Tasks will no longer be tagged resources. The inherited tags will help us keep track of what task is part of what service, project, deployment, and will allow us to track the cost of tasks. 

## Applicable Issues

Fixes #201 
