### PR TITLE
Implement a pattern for compliant logging to CloudWatch Logs

### DIFF
--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -196,7 +196,7 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
                 name=stream_name,
                 opts=pulumi.ResourceOptions(parent=self, depends_on=[__log_group]),
             )
-            for stream_id, stream_name in log_streams
+            for stream_id, stream_name in log_streams.items()
         }
 
         # Build an IAM Policy for each of several levels of access


### PR DESCRIPTION
## Description of the Change

We have developed a [series of logging guidelines at Thunderbird](https://github.com/thunderbird/observability/blob/main/docs/rfc/application_logging/application_logging_guidelines.md), and we have [described how CloudWatch Logs can implement those guidelines](https://github.com/thunderbird/observability/blob/main/docs/rfc/application_logging/logging_to_cloudwatch_logs.md). This PR is the real implementation of what is described in that document, **except** that it does not have the auditing capabilities. The auditing capabilities are *en route* with #261.

## Benefits

We'll have a way of stamping out log destinations throughout our projects, knowing they'll be compliant with our policies. If our policies change, we'll have a centralized place to implement those changes across projects.

## Applicable Issues

See #258.

## Test Implementation

I tested this by building a destination for Stalwart logs in the `mailstrom-dev` environment. I won't be committing this code until it's time to start setting that up for good there, but here's what I added so you can see the result.

To the `pulumi/__main__.py` file, I have added:

```python
# Build secure log destinations
log_dest_opts = resources.get('tb:cloudwatch:LogDestination', {})
log_destinations = {
    dest_name: tb_pulumi.cloudwatch.LogDestination(
        f'{project.name_prefix}-logdest-{dest_name}',
        project=project,
        **dest_config
    )
    for dest_name, dest_config in log_dest_opts.items()
}
```

To the `pulumi/config.dev.yaml` file, I have added:

```yaml
  tb:cloudwatch:LogDestination:
    stalwart:
      org_name: tb
      log_group:
        retention_in_days: 7
      log_streams:
        management-api: api
        mail-server: mail
```

And the result is the [`/tb/dev/mailstrom`](https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1#logsV2:log-groups/log-group/$252Ftb$252Fdev$252Fmailstrom) log group. I'll leave that up while this PR is open.