### PR TITLE
Allow AWSAutomationUser ecs:DescribeServices

### DIFF
--- a/tb_pulumi/ci.py
+++ b/tb_pulumi/ci.py
@@ -243,6 +243,7 @@ class AwsAutomationUser(tb_pulumi.ThunderbirdComponentResource):
                             'ec2:List*',
                             'ec2:Get*',
                             'ec2:Describe*',
+                            'ecs:DescribeServices',
                             'ecs:DeregisterTaskDefinition',
                             'elasticloadbalancing:Describe*',
                             's3:ListAllMyBuckets',


### PR DESCRIPTION
<!--
* Filling out the template is required.
* Please run through the PR checklist found in our documentation before submitting a pull request
  - https://thunderbird.github.io/pulumi/development.html#pull-request-requirements
-->

## Description of the Change

This pull request makes a minor update to the AWS permissions in the `tb_pulumi/ci.py` file, adding the `ecs:DescribeServices` action to the allowed actions list. This change enables the CI process to describe ECS services, which may be necessary for deployment or monitoring tasks.

## Benefits

In order to monitor ecs deloyment in CI/CD, we need permission to watch the deployment.
Ex. https://github.com/thunderbird/tbpro-add-on/blob/main/.github/workflows/merge.yml#L190
          `aws ecs wait services-stable --region eu-central-1 --cluster send-suite-stage-fargate --services send-suite-stage-fargate`

## Applicable Issues

<!-- Enter any applicable issues here -->
