### PR TITLE
Updates to Fargate logging resources

### DIFF
--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -18,6 +18,9 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
     with `Thunderbird logging guidelines
     <https://github.com/thunderbird/observability/blob/main/docs/rfc/application_logging/application_logging_guidelines.md>`_.
 
+    The name of the log group is constructed in the following way: ``/{org_name}/{stack_name}/{app_name}``. The first
+    segment will be left off if no org_name is provided.
+
     Produces the following ``resources``:
 
         - *key_alias* - `aws.kms.Alias <https://www.pulumi.com/registry/packages/aws/api-docs/kms/alias/>`_ used to name
@@ -39,6 +42,9 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
 
     :param project: The ``ThunderbirdPulumiProject`` to build monitoring resources for.
     :type project: tb_pulumi.ThunderbirdPulumiProject
+
+    :param app_name: Final part of the name of the log group. If no app_name is provided, the name of the project will
+        be used.
 
     :param log_group: Dict of inputs to an `aws.cloudwatch.LogGroup
         <https://www.pulumi.com/registry/packages/aws/api-docs/cloudwatch/loggroup/#inputs>`_. This class assumes some
@@ -82,6 +88,7 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
         self,
         name: str,
         project: tb_pulumi.ThunderbirdPulumiProject,
+        app_name: str = None,
         log_group: dict = {},
         log_streams: dict = {},
         org_name: str = None,
@@ -98,11 +105,12 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
             tags=tags,
         )
 
+        if not app_name:
+            app_name = self.project.project
+
         # Determine the log group's name before doing anything else; we need it for the key
         __log_group_name = (
-            f'/{org_name}/{self.project.stack}/{self.project.project}'
-            if org_name
-            else f'/{self.project.stack}/{self.project.project}'
+            f'/{org_name}/{self.project.stack}/{app_name}' if org_name else f'/{self.project.stack}/{app_name}'
         )
 
         # KMS Keys need policies to describe who can manage the keys and who can use them for encryption operations.

--- a/tb_pulumi/cloudwatch.py
+++ b/tb_pulumi/cloudwatch.py
@@ -261,7 +261,7 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
 
         __iam_policy_group_read = aws.iam.Policy(
             f'{self.project.name_prefix}-policy-read',
-            name=f'{self.project.name_prefix}-cloudwatch-group-read-access',
+            name=f'{self.project.name_prefix}-{app_name}-logs-read-access',
             description=__read_policy_description,
             path='/',
             policy=__iam_policy_group_read_doc,
@@ -273,7 +273,7 @@ class LogDestination(tb_pulumi.ThunderbirdComponentResource):
         )
         __iam_policy_group_write = aws.iam.Policy(
             f'{self.project.name_prefix}-policy-write',
-            name=f'{self.project.name_prefix}-cloudwatch-group-write-access',
+            name=f'{self.project.name_prefix}-{app_name}-logs-write-access',
             description=__write_policy_description,
             path='/',
             policy=__iam_policy_group_write_doc,

--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -91,9 +91,9 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
       the only valid source. Defaults to {}.
     :type container_security_groups: _type_, optional
 
-    :param exec_role_policies: A dict where the keys are the names of services and the values are lists of ARNs of IAM
-      Policies that service should operate with. These should provide permissions above and beyond what is provided by
-      using the ``registries``, ``secrets``, and ``ssm_params`` parameters.
+    :param extra_policies: A dict where the keys are the names of services and the values are lists of ARNs of IAM
+      Policies that service should operate with in addition to what is provided by using the ``registries``,
+      ``secrets``, and ``ssm_params`` parameters.
 
     :param listeners: A nested dict describing your load balancers' listeners and which targets they point to. At the
       top level, the keys are names of load balancers and the values are other dicts. Those dicts' keys are the names of
@@ -173,7 +173,7 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
         cluster: dict = {},
         cluster_name: str = None,
         container_security_groups: dict[str:dict] = {},
-        exec_role_policies: dict[str:list] = {},
+        extra_policies: dict[str:list] = {},
         listeners: dict[str, dict] = {},
         load_balancer_security_groups: dict[str, dict] = {},
         load_balancers: dict = {},
@@ -272,7 +272,6 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
                 f'{name}-execrolepolicy-{service}',
                 name=f'{name}-{service}',
                 description=f'Grants permissions needed to launch the {service} service for {self.project.name_prefix}',
-                managed_policy_arns=exec_role_policies.get(service),
                 policy=exec_role_policy_docs[service],
                 opts=pulumi.ResourceOptions(parent=self),
                 tags=self.tags,
@@ -281,21 +280,30 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
         }
 
         # Build the execution roles using the policies from above, if they exist
-        exec_roles = {
-            service: aws.iam.Role(
+        _universal_managed_policy_arns = [
+            # This AWS managed policy allows access to ECR and log streams
+            'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
+        ]
+
+        exec_roles = {}
+
+        for service in services.keys():
+            _managed_policy_arns = _universal_managed_policy_arns.copy()
+            _managed_policy_arns += [
+                item
+                for item in [
+                    exec_role_policies[service] if service in exec_role_policies else None,
+                ]
+                if item is not None
+            ]
+            _managed_policy_arns += extra_policies.get(service, [])
+
+            exec_roles[service] = aws.iam.Role(
                 f'{name}-execrole-{service}',
                 name=f'{name}-{service}',
                 description=f'Task execution role for running the {service} service for {self.project.name_prefix}',
                 assume_role_policy=arp,
-                managed_policy_arns=[
-                    item
-                    for item in [
-                        # This AWS managed policy allows access to ECR and log streams
-                        'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
-                        exec_role_policies[service] if service in exec_role_policies else None,
-                    ]
-                    if item is not None
-                ],
+                managed_policy_arns=_universal_managed_policy_arns + exec_role_policies.get('service', []),
                 tags=self.tags,
                 opts=pulumi.ResourceOptions(
                     parent=self,
@@ -306,8 +314,6 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
                     ],
                 ),
             )
-            for service in services.keys()
-        }
 
         # First we build out task definitions. Later, we can refer to them by name. Since task definitions are
         # one-to-one with cluster services, the task_name here is assumed to match with a service name.

--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -91,6 +91,10 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
       the only valid source. Defaults to {}.
     :type container_security_groups: _type_, optional
 
+    :param exec_role_policies: A dict where the keys are the names of services and the values are lists of ARNs of IAM
+      Policies that service should operate with. These should provide permissions above and beyond what is provided by
+      using the ``registries``, ``secrets``, and ``ssm_params`` parameters.
+
     :param listeners: A nested dict describing your load balancers' listeners and which targets they point to. At the
       top level, the keys are names of load balancers and the values are other dicts. Those dicts' keys are the names of
       targets, and their values are inputs to an `aws.lb.Listener
@@ -169,6 +173,7 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
         cluster: dict = {},
         cluster_name: str = None,
         container_security_groups: dict[str:dict] = {},
+        exec_role_policies: dict[str:list] = {},
         listeners: dict[str, dict] = {},
         load_balancer_security_groups: dict[str, dict] = {},
         load_balancers: dict = {},
@@ -267,6 +272,7 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
                 f'{name}-execrolepolicy-{service}',
                 name=f'{name}-{service}',
                 description=f'Grants permissions needed to launch the {service} service for {self.project.name_prefix}',
+                managed_policy_arns=exec_role_policies.get(service),
                 policy=exec_role_policy_docs[service],
                 opts=pulumi.ResourceOptions(parent=self),
                 tags=self.tags,

--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -280,15 +280,13 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
         }
 
         # Build the execution roles using the policies from above, if they exist
-        _universal_managed_policy_arns = [
-            # This AWS managed policy allows access to ECR and log streams
-            'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
-        ]
-
         exec_roles = {}
 
         for service in services.keys():
-            _managed_policy_arns = _universal_managed_policy_arns.copy()
+            _managed_policy_arns = [
+                # This AWS managed policy allows access to ECR and log streams
+                'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
+            ]
             _managed_policy_arns += [
                 item
                 for item in [

--- a/tb_pulumi/fargate.py
+++ b/tb_pulumi/fargate.py
@@ -303,7 +303,7 @@ class AutoscalingFargateCluster(tb_pulumi.ThunderbirdComponentResource):
                 name=f'{name}-{service}',
                 description=f'Task execution role for running the {service} service for {self.project.name_prefix}',
                 assume_role_policy=arp,
-                managed_policy_arns=_universal_managed_policy_arns + exec_role_policies.get('service', []),
+                managed_policy_arns=_managed_policy_arns,
                 tags=self.tags,
                 opts=pulumi.ResourceOptions(
                     parent=self,


### PR DESCRIPTION
## Description of the Change

There are a few things fixed/updated here.

To `cloudwatch.LogDestination`:

  - Add `app_name` parameter, which allows the user to better control what a log group is going to be called.
  - Fix the names of the policies that grant access to log groups/streams so they're unique and easier to identify.

To `fargate.AutoscalingFargateCluster`:

  - Add `extra_policies` parameter, which allows the user to attach arbitrary additional policies to a container's execution role, which enables us to let, for example, the fluent-bit cluster in `observability` write to log groups created for Stalwart.