### PR TITLE
Fix route resource type mixing bug

### DIFF
--- a/tb_pulumi/network.py
+++ b/tb_pulumi/network.py
@@ -646,7 +646,8 @@ class MultiTierVpc(tb_pulumi.ThunderbirdComponentResource):
                         {
                             'cidr_block': '0.0.0.0/0',
                             'gateway_id': internet_gateway.id,
-                        }
+                        },
+                        *additional_routes.get('public', []),
                     ],
                     tags={'Name': f'{name}-public-rt', **self.tags},
                     opts=pulumi.ResourceOptions(parent=self, depends_on=[vpc, internet_gateway]),
@@ -704,7 +705,7 @@ class MultiTierVpc(tb_pulumi.ThunderbirdComponentResource):
                 opts=pulumi.ResourceOptions(parent=self, depends_on=[nat_eip, public_subnet_rs[0]]),
             )
 
-            # Create a rotue table for the private subnets
+            # Create a route table for the private subnets
             private_route_table = (
                 aws.ec2.RouteTable(
                     f'{name}-private-rt',
@@ -713,7 +714,8 @@ class MultiTierVpc(tb_pulumi.ThunderbirdComponentResource):
                         {
                             'cidr_block': '0.0.0.0/0',
                             'nat_gateway_id': nat_gateway.id,
-                        }
+                        },
+                        *additional_routes.get('private', []),
                     ],
                     tags={'Name': f'{name}-private-rt', **self.tags},
                     opts=pulumi.ResourceOptions(parent=self, depends_on=[vpc, nat_gateway]),
@@ -853,34 +855,12 @@ class MultiTierVpc(tb_pulumi.ThunderbirdComponentResource):
                 for idx, cidr in enumerate(peered_cidrs)
             ]
 
-        # Build any additional private and public routes
-        additional_private_routes = [
-            aws.ec2.Route(
-                f'{name}-route-{idx}',
-                route_table_id=private_route_table.id,
-                opts=pulumi.ResourceOptions(parent=self, depends_on=[vpc]),
-                **route,
-            )
-            for idx, route in enumerate(additional_routes.get('private', []))
-        ]
-        additional_public_routes = [
-            aws.ec2.Route(
-                f'{name}-route-{idx}',
-                route_table_id=public_route_table.id,
-                opts=pulumi.ResourceOptions(parent=self, depends_on=[vpc]),
-                **route,
-            )
-            for idx, route in enumerate(additional_routes.get('public', []))
-        ]
-
         # Combine all routes we've created into one list; remove any optional routes which are disabled/None
         routes = [
             route
             for route in [
                 *peer_conn_routes.values(),
                 *peer_acc_routes.values(),
-                *additional_private_routes,
-                *additional_public_routes,
             ]
             if route is not None
         ]

--- a/tb_pulumi/network.py
+++ b/tb_pulumi/network.py
@@ -712,7 +712,7 @@ class MultiTierVpc(tb_pulumi.ThunderbirdComponentResource):
                     routes=[
                         {
                             'cidr_block': '0.0.0.0/0',
-                            'gateway_id': nat_gateway.id,
+                            'nat_gateway_id': nat_gateway.id,
                         }
                     ],
                     tags={'Name': f'{name}-private-rt', **self.tags},


### PR DESCRIPTION
Prior to this PR, we would create a RouteTable and include an inline rule for egress via the NAT or Internet Gateway. Farther down, we would create arbitrarily configured Route resources and attach them to the same route table. Technically, this works when you apply it. But on the backend, AWS merges this down into a single RouteTable with multiple in-line routes.

This doesn't even present a problem until you do a `pulumi refresh`, in which case the local state sees the change on the backend and decides it wants to delete the additional route entirely. This particular change represents a full outage.

This PR changes this so that the additional routes are incorporated into the in-line routing. I do this here _**knowing full well**_ that this problem could appear if we were to introduce a new peering connection request into an environment using this code. However, we will not. This codebase is on its way out. The only place we need this code change for is mailstrom, which does not and will not have any new outbound peering connection requests made before the environments are retired. The other environments that do this are not getting this code change since they are pinned to other versions. It is possible that this problem would present in those if we did a refresh there. If that happens, I'll deal with it then. This is a quick patch maintenance change that has been tested to resolve outage-causing drift in mailstrom-prod.